### PR TITLE
fix: use http2.Transport for direct connections and lower scrypt cost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/klauspost/compress v1.17.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,3 +34,5 @@ golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=

--- a/internal/account/crypto.go
+++ b/internal/account/crypto.go
@@ -40,7 +40,7 @@ func (c *Crypto) DeriveKey(salt string) ([]byte, error) {
 	}
 	c.mu.RUnlock()
 
-	key, err := scrypt.Key([]byte(c.encryptionKey), []byte(salt), 32768, 8, 1, 32)
+	key, err := scrypt.Key([]byte(c.encryptionKey), []byte(salt), 16384, 8, 1, 32)
 	if err != nil {
 		return nil, fmt.Errorf("scrypt derive: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **transport.go**: 直连场景从 `http.Transport` 切换为 `http2.Transport`，解决 utls `UConn` 无法通过 `*tls.Conn` 类型断言导致 HTTP/2 协商失败的问题
- **crypto.go**: scrypt N 参数从 32768 降低到 16384，加速密钥派生
- **go.mod / go.sum**: 新增 `golang.org/x/text` 间接依赖（`http2` 包需要）

## Changes

### `internal/transport/transport.go`
- `poolEntry.transport` → `poolEntry.roundTripper`（`http.RoundTripper` 接口）
- `getTransport()` → `getRoundTripper()`，返回 `http.RoundTripper`
- `buildTransport()` → `buildRoundTripper()`：直连用 `http2.Transport` + utls，代理场景保持 `http.Transport`
- `GetHTTPTransport()` 仅在有代理时返回 `*http.Transport`，否则返回 nil
- `Close()` 和 `cleanup()` 通过接口断言调用 `CloseIdleConnections()`

### `internal/account/crypto.go`
- scrypt `N` 从 `32768` 改为 `16384`

## Test plan
- [ ] 验证直连场景下 HTTP/2 请求正常工作
- [ ] 验证代理场景下请求正常工作
- [ ] 验证 token 刷新流程在有/无代理时均正常
- [ ] 验证加密/解密功能在新 scrypt 参数下正常