### PR TITLE
fix: Codex account dedup uses org-level ID, causing accounts to overwrite each other

### DIFF
--- a/internal/server/admin_oauth.go
+++ b/internal/server/admin_oauth.go
@@ -218,11 +218,12 @@ func (s *Server) exchangeCodexCode(w http.ResponseWriter, r *http.Request, code,
 	}
 	extInfoJSON, _ := json.Marshal(extInfo)
 
-	// Dedup: find existing codex account by chatgptAccountId
-	chatgptAccountID, _ := extInfo["chatgptAccountId"].(string)
+	// Dedup: find existing codex account by email (user-level unique).
+	// NOTE: chatgptAccountId is org-level, shared across users in the same
+	// ChatGPT workspace, so it cannot be used as a dedup key.
 	var existing *account.Account
-	if chatgptAccountID != "" {
-		existing, err = s.findAccountByExtInfoKey(r, "chatgptAccountId", chatgptAccountID)
+	if email != "" {
+		existing, err = s.findAccountByExtInfoKey(r, "email", email)
 		if err != nil {
 			slog.Error("list accounts failed", "error", err)
 		}


### PR DESCRIPTION
## Summary
- Codex 账号去重 key 从 `chatgptAccountId` 改为 `email`
- `chatgptAccountId` 是 ChatGPT 组织级 ID，同一 workspace 下所有用户共享，导致后添加的账号会覆盖先添加的
- `email` 是用户级唯一标识，正确区分不同用户

## Test plan
- [ ] 同一 ChatGPT 组织下两个不同用户分别添加 Codex 账号，确认两个账号独立存在
- [ ] 同一用户重复添加，确认走更新逻辑而非创建新账号