### PR TITLE
fix: use browser timezone for usage stats

### DIFF
--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -82,7 +82,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	uptime := fmt.Sprintf("%dd %dh %dm", days, hours, mins)
 
 	// Usage periods
-	usage, err := s.store.QueryUsagePeriods(ctx, "")
+	loc := parseTZParam(r)
+	usage, err := s.store.QueryUsagePeriods(ctx, "", loc)
 	if err != nil {
 		slog.Warn("dashboard: query usage periods failed", "error", err)
 	}
@@ -209,6 +210,20 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		Uptime:  uptime,
 		Version: s.version,
 	})
+}
+
+// parseTZParam extracts the "tz" query parameter (IANA timezone name)
+// and returns the corresponding *time.Location. Falls back to UTC.
+func parseTZParam(r *http.Request) *time.Location {
+	tz := r.URL.Query().Get("tz")
+	if tz == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/admin_users.go
+++ b/internal/server/admin_users.go
@@ -176,7 +176,8 @@ func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	usage, err := s.store.QueryUsagePeriods(ctx, id)
+	loc := parseTZParam(r)
+	usage, err := s.store.QueryUsagePeriods(ctx, id, loc)
 	if err != nil {
 		slog.Warn("user detail: query usage periods failed", "error", err, "userId", id)
 	}

--- a/internal/store/mock_store.go
+++ b/internal/store/mock_store.go
@@ -173,7 +173,7 @@ func (m *MockStore) PurgeOldLogs(_ context.Context, _ time.Time) (int64, error) 
 	return 0, nil
 }
 
-func (m *MockStore) QueryUsagePeriods(_ context.Context, _ string) ([]domain.UsagePeriod, error) {
+func (m *MockStore) QueryUsagePeriods(_ context.Context, _ string, _ *time.Location) ([]domain.UsagePeriod, error) {
 	return nil, nil
 }
 

--- a/internal/store/sqlite_logs.go
+++ b/internal/store/sqlite_logs.go
@@ -79,9 +79,12 @@ func buildLogWhere(userID, accountID string) (string, []interface{}) {
 	return where, args
 }
 
-func (s *SQLiteStore) QueryUsagePeriods(ctx context.Context, userID string) ([]domain.UsagePeriod, error) {
-	now := time.Now().UTC()
-	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+func (s *SQLiteStore) QueryUsagePeriods(ctx context.Context, userID string, loc *time.Location) ([]domain.UsagePeriod, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 	yesterdayStart := todayStart.Add(-24 * time.Hour)
 
 	periods := []struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -35,7 +35,7 @@ type Store interface {
 	PurgeOldLogs(ctx context.Context, before time.Time) (int64, error)
 
 	// Dashboard & analytics
-	QueryUsagePeriods(ctx context.Context, userID string) ([]domain.UsagePeriod, error)
+	QueryUsagePeriods(ctx context.Context, userID string, loc *time.Location) ([]domain.UsagePeriod, error)
 	QueryUserTotalCosts(ctx context.Context) (map[string]float64, error)
 	QueryModelUsage(ctx context.Context, userID string) ([]domain.ModelUsageRow, error)
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,8 +10,13 @@ export async function api<T = unknown>(path: string, opts: RequestInit = {}): Pr
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 15000);
 
+	// Append browser timezone for accurate "today"/"yesterday" stats
+	const sep = path.includes('?') ? '&' : '?';
+	const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const url = `/admin${path}${sep}tz=${encodeURIComponent(tz)}`;
+
 	try {
-		const res = await fetch(`/admin${path}`, {
+		const res = await fetch(url, {
 			credentials: 'same-origin',
 			signal: controller.signal,
 			headers: {


### PR DESCRIPTION
## Summary
- Usage stats (today/yesterday) were calculated using UTC midnight boundaries, causing incorrect period grouping for non-UTC users
- Frontend now sends the browser's IANA timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) via `?tz=` query parameter
- Backend `QueryUsagePeriods` uses the provided timezone to calculate correct today/yesterday boundaries
- Falls back to UTC if no timezone is provided or if the timezone name is invalid

## Test plan
- [ ] Verify "today" stats match requests made since local midnight (not UTC midnight)
- [ ] Verify "yesterday" stats correspond to the user's local yesterday
- [ ] Verify fallback to UTC when `tz` param is missing or invalid
- [ ] Verify rolling periods (3/7/30 days) still work correctly