### PR TITLE
fix: replace ReadTimeout with ReadHeaderTimeout for high-latency clients

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,8 +69,9 @@ func New(
 		Addr:           fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		Handler:        requestLogger(mux),
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:   cfg.RequestTimeout + 30*time.Second,
-		MaxHeaderBytes: 1 << 20,
+		WriteTimeout:      cfg.RequestTimeout + 30*time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
 	}
 
 	return srv

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,7 +68,7 @@ func New(
 	srv.httpServer = &http.Server{
 		Addr:           fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		Handler:        requestLogger(mux),
-		ReadTimeout:    30 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:   cfg.RequestTimeout + 30*time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}


### PR DESCRIPTION
## Problem

Relay deployments where the server is geographically distant from clients (e.g. server in UK, clients in Asia) produce frequent request body read failures:

```
RELAY_ERROR claude: failed to parse request body: read tcp 127.0.0.1:3000->127.0.0.1:53048: i/o timeout
RELAY_ERROR claude: failed to parse request body: unexpected EOF
RELAY_ERROR codex: failed to read request body: unexpected EOF
```

These errors occur because Go's `http.Server.ReadTimeout` starts counting from **connection acceptance** — covering TLS handshake, header read, and the entire body transfer. With a 30-second deadline, large request bodies containing full conversation context frequently timeout over high-latency links.

Two failure modes:
- **i/o timeout**: body transfer doesn't complete within `ReadTimeout`
- **unexpected EOF**: client detects the impending timeout and disconnects, or the connection is killed mid-transfer

## Root Cause

```go
// server.go — current
ReadTimeout: 30 * time.Second,  // wall-clock from accept → full body read
```

`ReadTimeout` is a blunt instrument. It protects against slow clients but doesn't distinguish between "headers haven't arrived" (attack vector) and "body is still uploading" (legitimate large request over slow link).

## Fix

```go
// server.go — proposed
ReadHeaderTimeout: 10 * time.Second,  // only bounds header phase
```

- `ReadHeaderTimeout` constrains only the header reading phase — sufficient to prevent [slowloris attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security))
- Body reads proceed without an artificial time ceiling
- `WriteTimeout` (already set to `cfg.RequestTimeout + 30s`) continues to govern response-side deadlines
- This is the [recommended pattern](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) for Go HTTP servers that accept large request bodies

## Test Plan

- [x] `go build ./...` compiles
- [ ] Deploy to production and monitor for reduction in `i/o timeout` / `unexpected EOF` errors