### PR TITLE
fix: add missing json tags to TokenResponse struct

### DIFF
--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -57,9 +57,9 @@ type Usage struct {
 
 // TokenResponse is the OAuth refresh/exchange response.
 type TokenResponse struct {
-	AccessToken  string
-	RefreshToken string
-	ExpiresIn    int
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
 }
 
 // ExchangeResult holds the tokens and identity from an authorization code exchange.


### PR DESCRIPTION
## Summary

- OAuth token exchange fails with `"empty access_token in response"` when adding new Claude accounts
- Root cause: `bfcd7ec` (absorb OAuth into driver package) dropped json tags from `TokenResponse` — `access_token` cannot map to `AccessToken` without tags
- Fix: restore `json:"access_token"`, `json:"refresh_token"`, `json:"expires_in"` tags

## Test plan

- `go build ./...` and `go test ./...` pass
- Add a new Claude account via the dashboard and verify token exchange succeeds