### PR TITLE
修复 context.Canceled 误判为 transport error + 新增 upstream 500 circuit breaker

### DIFF
--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yansircc/llm-broker/internal/identity"
 )
 
-var banSignalPattern = regexp.MustCompile(`(?i)(organization has been disabled|account has been disabled|Too many active sessions|only authorized for use with claude code)`)
+var banSignalPattern = regexp.MustCompile(`(?i)(organization has been disabled|account has been disabled|Too many active sessions|only authorized for use with claude code|OAuth authentication is currently not allowed)`)
 
 // ---------------------------------------------------------------------------
 // Relay

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -145,6 +145,13 @@ func (d *ClaudeDriver) Interpret(statusCode int, headers http.Header, body []byt
 			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401Refresh),
 			UpdatedState:  mustMarshalJSON(state),
 		}
+
+	case 500:
+		return Effect{
+			Kind:         EffectServerError,
+			Scope:        EffectScopeBucket,
+			UpdatedState: mustMarshalJSON(state),
+		}
 	}
 
 	return Effect{Kind: EffectSuccess, Scope: EffectScopeBucket, UpdatedState: mustMarshalJSON(state)}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -20,11 +20,12 @@ type ErrorPauses struct {
 type EffectKind int
 
 const (
-	EffectSuccess  EffectKind = iota
-	EffectCooldown            // 429, 403 non-ban
-	EffectOverload            // 529
-	EffectBlock               // 403 ban
-	EffectAuthFail            // 401
+	EffectSuccess     EffectKind = iota
+	EffectCooldown               // 429, 403 non-ban
+	EffectOverload               // 529
+	EffectBlock                  // 403 ban
+	EffectAuthFail               // 401
+	EffectServerError            // 500
 )
 
 // EffectScope determines whether an effect applies to one credential or an entire bucket.

--- a/internal/neterr/neterr.go
+++ b/internal/neterr/neterr.go
@@ -8,8 +8,13 @@ import (
 )
 
 // IsTransport reports whether err looks like a network or proxy transport failure.
+// It explicitly excludes context.Canceled, which indicates the downstream client
+// disconnected rather than an infrastructure problem with the network path.
 func IsTransport(err error) bool {
 	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
 		return false
 	}
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/neterr/neterr_test.go
+++ b/internal/neterr/neterr_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"testing"
 )
 
@@ -32,6 +33,26 @@ func TestIsTransport(t *testing.T) {
 	t.Run("application error", func(t *testing.T) {
 		if IsTransport(errors.New("oauth returned 400: bad request")) {
 			t.Fatal("unexpected transport classification")
+		}
+	})
+
+	t.Run("context canceled is not transport", func(t *testing.T) {
+		if IsTransport(context.Canceled) {
+			t.Fatal("bare context.Canceled should not be classified as transport")
+		}
+	})
+
+	t.Run("url.Error wrapping context canceled is not transport", func(t *testing.T) {
+		// http.Client.Do returns *url.Error which implements net.Error.
+		// Without the context.Canceled guard, errors.As(err, &netErr)
+		// matches and the error is misclassified as a transport failure.
+		err := &url.Error{
+			Op:  "Post",
+			URL: "https://api.anthropic.com/v1/messages",
+			Err: context.Canceled,
+		}
+		if IsTransport(err) {
+			t.Fatal("*url.Error wrapping context.Canceled should not be classified as transport")
 		}
 	})
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -27,12 +27,13 @@ func ExcludeBucket(bucketKey string) Exclusion {
 }
 
 type Pool struct {
-	mu       sync.RWMutex
-	accounts map[string]*domain.Account
-	cells    map[string]*domain.EgressCell
-	buckets  map[string]*domain.QuotaBucket
-	store    store.Store
-	bus      *events.Bus
+	mu             sync.RWMutex
+	accounts       map[string]*domain.Account
+	cells          map[string]*domain.EgressCell
+	buckets        map[string]*domain.QuotaBucket
+	serverErrCount map[string]int // consecutive upstream 500s per bucket key
+	store          store.Store
+	bus            *events.Bus
 
 	onAuthFailure func(accountID string)
 	drivers       map[domain.Provider]driver.SchedulerDriver
@@ -44,11 +45,12 @@ func (p *Pool) SetOnAuthFailure(fn func(accountID string)) {
 
 func New(s store.Store, bus *events.Bus) (*Pool, error) {
 	p := &Pool{
-		accounts: make(map[string]*domain.Account),
-		cells:    make(map[string]*domain.EgressCell),
-		buckets:  make(map[string]*domain.QuotaBucket),
-		store:    s,
-		bus:      bus,
+		accounts:       make(map[string]*domain.Account),
+		cells:          make(map[string]*domain.EgressCell),
+		buckets:        make(map[string]*domain.QuotaBucket),
+		serverErrCount: make(map[string]int),
+		store:          s,
+		bus:            bus,
 	}
 
 	if err := p.refreshState(context.Background()); err != nil {

--- a/internal/pool/pool_observe.go
+++ b/internal/pool/pool_observe.go
@@ -155,6 +155,28 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		now := time.Now().UTC()
 		acct.LastUsedAt = &now
 		markPersist(acct)
+		if bucket != nil {
+			delete(p.serverErrCount, bucket.BucketKey)
+		}
+
+	case driver.EffectServerError:
+		now := time.Now().UTC()
+		acct.LastUsedAt = &now
+		markPersist(acct)
+		if bucket != nil {
+			p.serverErrCount[bucket.BucketKey]++
+			if p.serverErrCount[bucket.BucketKey] >= 3 {
+				cooldownUntil := time.Now().Add(30 * time.Second)
+				p.applyBucketCooldown(bucket, cooldownUntil)
+				bucket.UpdatedAt = time.Now().UTC()
+				p.persistBucketLocked(bucket)
+				delete(p.serverErrCount, bucket.BucketKey)
+				p.bus.Publish(events.Event{
+					Type: events.EventOverload, AccountID: acct.ID,
+					Message: "circuit breaker: 3 consecutive upstream 500s, cooldown 30s",
+				})
+			}
+		}
 
 	case driver.EffectCooldown:
 		p.applyBucketCooldown(bucket, effect.CooldownUntil)

--- a/internal/pool/pool_observe.go
+++ b/internal/pool/pool_observe.go
@@ -150,14 +150,18 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		}
 	}
 
+	// Reset circuit breaker counter on any non-500 outcome.
+	// Only EffectServerError should accumulate; interleaved 429/401/etc.
+	// break the "consecutive" chain.
+	if effect.Kind != driver.EffectServerError && bucket != nil {
+		delete(p.serverErrCount, bucket.BucketKey)
+	}
+
 	switch effect.Kind {
 	case driver.EffectSuccess:
 		now := time.Now().UTC()
 		acct.LastUsedAt = &now
 		markPersist(acct)
-		if bucket != nil {
-			delete(p.serverErrCount, bucket.BucketKey)
-		}
 
 	case driver.EffectServerError:
 		now := time.Now().UTC()

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -717,3 +717,60 @@ func TestObserve_BucketScopeSyncsCooldownAndState(t *testing.T) {
 		}
 	}
 }
+
+func TestCircuitBreakerOnServerError(t *testing.T) {
+	acct := activeAccount("cb-1", "cb@test.com")
+	p := newTestPool(t, acct)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: testDriver,
+	})
+
+	bucketKey := testDriver.BucketKey(acct)
+
+	// First two EffectServerError should NOT trigger cooldown.
+	for i := 0; i < 2; i++ {
+		p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+		bucket := p.buckets[bucketKey]
+		if bucket != nil && bucket.CooldownUntil != nil {
+			t.Fatalf("unexpected cooldown after %d server errors", i+1)
+		}
+	}
+
+	// Third should trigger cooldown.
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	bucket := p.buckets[bucketKey]
+	if bucket == nil || bucket.CooldownUntil == nil {
+		t.Fatal("expected cooldown after 3 consecutive server errors")
+	}
+	if bucket.CooldownUntil.Before(time.Now()) {
+		t.Fatal("cooldown should be in the future")
+	}
+}
+
+func TestCircuitBreakerResetOnSuccess(t *testing.T) {
+	acct := activeAccount("cb-2", "cb2@test.com")
+	p := newTestPool(t, acct)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: testDriver,
+	})
+
+	bucketKey := testDriver.BucketKey(acct)
+
+	// Two server errors, then a success should reset the counter.
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectSuccess, Scope: driver.EffectScopeBucket})
+
+	if count := p.serverErrCount[bucketKey]; count != 0 {
+		t.Fatalf("expected counter reset after success, got %d", count)
+	}
+
+	// After reset, need 3 more errors to trigger cooldown.
+	for i := 0; i < 2; i++ {
+		p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	}
+	bucket := p.buckets[bucketKey]
+	if bucket != nil && bucket.CooldownUntil != nil {
+		t.Fatal("unexpected cooldown after only 2 server errors post-reset")
+	}
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -774,3 +774,24 @@ func TestCircuitBreakerResetOnSuccess(t *testing.T) {
 		t.Fatal("unexpected cooldown after only 2 server errors post-reset")
 	}
 }
+
+func TestCircuitBreakerResetOnNon500Effect(t *testing.T) {
+	acct := activeAccount("cb-3", "cb3@test.com")
+	p := newTestPool(t, acct)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: testDriver,
+	})
+
+	bucketKey := testDriver.BucketKey(acct)
+
+	// Sequence: 500 → 429 → 500 → 500 should NOT trigger circuit breaker
+	// because the 429 breaks the consecutive chain.
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectCooldown, Scope: driver.EffectScopeBucket, CooldownUntil: time.Now().Add(-time.Second)})
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+	p.Observe(acct.ID, driver.Effect{Kind: driver.EffectServerError, Scope: driver.EffectScopeBucket})
+
+	if count := p.serverErrCount[bucketKey]; count != 2 {
+		t.Fatalf("expected counter = 2 after 429 reset, got %d", count)
+	}
+}

--- a/internal/relay/relay_attempt.go
+++ b/internal/relay/relay_attempt.go
@@ -170,7 +170,14 @@ func (r *Relay) executeRelayAttempt(
 			CreatedAt:  time.Now().UTC(),
 		})
 
-		effect := drv.Interpret(http.StatusOK, resp.Header, nil, prepared.input.Model, json.RawMessage(acct.ProviderStateJSON))
+		// Pass real status for 500 so the driver can return EffectServerError
+		// for circuit-breaker tracking. Other non-retriable codes keep using
+		// StatusOK so Interpret just captures rate-limit headers as before.
+		interpretStatus := http.StatusOK
+		if resp.StatusCode == http.StatusInternalServerError {
+			interpretStatus = resp.StatusCode
+		}
+		effect := drv.Interpret(interpretStatus, resp.Header, nil, prepared.input.Model, json.RawMessage(acct.ProviderStateJSON))
 		r.pool.Observe(acct.ID, effect)
 
 		slog.Warn("upstream non-retriable error",


### PR DESCRIPTION
## 问题一：context.Canceled 被误判为 transport error

下游客户端在上游请求进行中断开连接时，Go 的 `http.Client.Do` 返回 `*url.Error` 包裹的 `context.Canceled`。由于 Go 1.6 起 `*url.Error` 实现了 `net.Error` 接口（[golang/go#12866](https://github.com/golang/go/issues/12866)），`neterr.IsTransport` 中的 `errors.As(err, &netErr)` 会匹配成功，将客户端断开误判为网络基础设施故障。

这导致 `CooldownCell` 被调用，**整个 cell 被冷却 60 秒**——但实际上 cell 和代理完全正常，只是客户端主动断开了。

### 修复

在 `IsTransport` 开头增加 `errors.Is(err, context.Canceled)` 检查，在 `net.Error` 接口匹配之前提前返回 `false`。

---

## 问题二：upstream 500 无 circuit breaker

Anthropic 返回连续 `500 Internal Server Error` 时，broker 持续把所有请求路由到同一个最高优先级账号——因为 500 不在 `ShouldRetry` 列表里，也不会产生任何池状态变更。生产环境中，同一个账号在 2 分钟内连续收到 60+ 个 500，影响多个用户。

### 修复

通过现有的 Effect/Observe 管道新增 per-bucket circuit breaker：

1. `driver.Effect` 新增 `EffectServerError` 类型
2. Claude 的 `Interpret` 对 500 返回 `EffectServerError`（仍然捕获 rate-limit 响应头）
3. `pool.Observe` 跟踪每个 bucket 的连续 server error 计数——**连续 3 次 500 后，冷却 30 秒**
4. 任何成功请求重置计数器

---

## 问题三：OAuth org 禁用未被识别为 ban signal

Anthropic 返回 `403 "OAuth authentication is currently not allowed for this organization."` 时，该错误不在 `banSignalPattern` 中，导致 broker 在同一个账号上无限循环重试 + 短暂 cooldown。生产日志中 10 分钟内产生了 243 条相同错误。

### 修复

将 `"OAuth authentication is currently not allowed"` 加入 `banSignalPattern`，触发 `EffectBlock`，账号被标记为 blocked 并进入较长冷却期。冷却到期后 cleanup 自动恢复为 active。

---

## 测试

- [x] `neterr`：裸 `context.Canceled` 和 `*url.Error` 包裹 `context.Canceled` 的测试
- [x] `pool`：连续 3 次 `EffectServerError` 后触发 cooldown
- [x] `pool`：`EffectSuccess` 重置 circuit breaker 计数器
- [x] 全量测试通过，无回归