### PR TITLE
Add 529 overload recovery: probe-before-clear + friendly error

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -35,6 +35,8 @@ type Pool struct {
 	store          store.Store
 	bus            *events.Bus
 
+	overloadBackoff map[string]*overloadState // in-memory overload tracking per bucket
+
 	onAuthFailure func(accountID string)
 	drivers       map[domain.Provider]driver.SchedulerDriver
 }
@@ -45,12 +47,13 @@ func (p *Pool) SetOnAuthFailure(fn func(accountID string)) {
 
 func New(s store.Store, bus *events.Bus) (*Pool, error) {
 	p := &Pool{
-		accounts:       make(map[string]*domain.Account),
-		cells:          make(map[string]*domain.EgressCell),
-		buckets:        make(map[string]*domain.QuotaBucket),
-		serverErrCount: make(map[string]int),
-		store:          s,
-		bus:            bus,
+		accounts:        make(map[string]*domain.Account),
+		cells:           make(map[string]*domain.EgressCell),
+		buckets:         make(map[string]*domain.QuotaBucket),
+		serverErrCount:  make(map[string]int),
+		overloadBackoff: make(map[string]*overloadState),
+		store:           s,
+		bus:             bus,
 	}
 
 	if err := p.refreshState(context.Background()); err != nil {

--- a/internal/pool/pool_accounts.go
+++ b/internal/pool/pool_accounts.go
@@ -39,6 +39,7 @@ func (p *Pool) ClearCooldown(accountID string) {
 	if bucket == nil || bucket.CooldownUntil == nil {
 		return
 	}
+	p.clearOverloadLocked(bucket.BucketKey)
 	bucket.CooldownUntil = nil
 	bucket.UpdatedAt = time.Now().UTC()
 	p.persistBucketLocked(bucket)
@@ -180,6 +181,7 @@ func (p *Pool) StoreTokens(accountID, accessTokenEnc, refreshTokenEnc string, ex
 	acct.Status = domain.StatusActive
 	acct.ErrorMessage = ""
 	if bucket := p.ensureBucketLocked(acct); bucket != nil && bucket.CooldownUntil != nil {
+		p.clearOverloadLocked(bucket.BucketKey)
 		bucket.CooldownUntil = nil
 		bucket.UpdatedAt = now
 		p.persistBucketLocked(bucket)

--- a/internal/pool/pool_observe.go
+++ b/internal/pool/pool_observe.go
@@ -53,6 +53,10 @@ func (p *Pool) cleanup() {
 	// Phase 1: bucket-scoped decisions. Each bucket is visited exactly once.
 	for _, bucket := range p.buckets {
 		if bucket.CooldownUntil != nil && now.After(*bucket.CooldownUntil) {
+			// Overloaded buckets are recovered by the probe goroutine, not cleanup.
+			if p.isOverloadBucketLocked(bucket.BucketKey) {
+				continue
+			}
 			// Check if any member is blocked — if so, defer clearing to
 			// phase 2 so blocked recovery sees the non-nil cooldown.
 			hasBlocked := false
@@ -100,6 +104,10 @@ func (p *Pool) cleanup() {
 	// and enforce exhausted cooldowns on now-available buckets.
 	for _, bucket := range p.buckets {
 		if bucket.CooldownUntil != nil && now.After(*bucket.CooldownUntil) {
+			// Overloaded buckets are recovered by the probe goroutine, not cleanup.
+			if p.isOverloadBucketLocked(bucket.BucketKey) {
+				continue
+			}
 			bucket.CooldownUntil = nil
 			bucket.UpdatedAt = now.UTC()
 			p.persistBucketLocked(bucket)
@@ -222,6 +230,9 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		now := time.Now().UTC()
 		acct.LastUsedAt = &now
 		markPersist(acct)
+		if bucket != nil {
+			p.clearOverloadLocked(bucket.BucketKey)
+		}
 
 	case driver.EffectServerError:
 		now := time.Now().UTC()
@@ -261,6 +272,7 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		if bucket != nil {
 			bucket.UpdatedAt = time.Now().UTC()
 			p.persistBucketLocked(bucket)
+			p.markOverloadLocked(bucket.BucketKey)
 		}
 		pendingEvent = &events.Event{
 			Type: events.EventOverload, AccountID: acct.ID,

--- a/internal/pool/pool_overload.go
+++ b/internal/pool/pool_overload.go
@@ -1,0 +1,175 @@
+package pool
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/yansircc/llm-broker/internal/domain"
+	"github.com/yansircc/llm-broker/internal/events"
+)
+
+type overloadState struct {
+	since             time.Time
+	consecutiveProbes int
+}
+
+// OverloadBucketInfo describes an overloaded bucket ready for probing.
+type OverloadBucketInfo struct {
+	BucketKey string
+	Provider  domain.Provider
+}
+
+// markOverloadLocked sets overload state for a bucket if not already set.
+// Caller must hold p.mu.
+func (p *Pool) markOverloadLocked(bucketKey string) {
+	if _, ok := p.overloadBackoff[bucketKey]; ok {
+		return
+	}
+	p.overloadBackoff[bucketKey] = &overloadState{
+		since: time.Now(),
+	}
+}
+
+// clearOverloadLocked removes overload state for a bucket.
+// Caller must hold p.mu.
+func (p *Pool) clearOverloadLocked(bucketKey string) {
+	delete(p.overloadBackoff, bucketKey)
+}
+
+// isOverloadBucketLocked checks if a bucket is in overload state.
+// Caller must hold p.mu.
+func (p *Pool) isOverloadBucketLocked(bucketKey string) bool {
+	_, ok := p.overloadBackoff[bucketKey]
+	return ok
+}
+
+// OverloadedBucketsReady returns overloaded buckets whose cooldown has expired,
+// meaning they are ready for a probe attempt.
+func (p *Pool) OverloadedBucketsReady() []OverloadBucketInfo {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	now := time.Now()
+	var ready []OverloadBucketInfo
+	for bucketKey := range p.overloadBackoff {
+		bucket, ok := p.buckets[bucketKey]
+		if !ok {
+			continue
+		}
+		if bucket.CooldownUntil != nil && now.Before(*bucket.CooldownUntil) {
+			continue
+		}
+		ready = append(ready, OverloadBucketInfo{
+			BucketKey: bucketKey,
+			Provider:  bucket.Provider,
+		})
+	}
+	return ready
+}
+
+// ClearOverload clears overload state, cooldown, and emits a recovery event.
+func (p *Pool) ClearOverload(bucketKey string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.clearOverloadLocked(bucketKey)
+	bucket, ok := p.buckets[bucketKey]
+	if !ok {
+		return
+	}
+	if bucket.CooldownUntil != nil {
+		bucket.CooldownUntil = nil
+		bucket.UpdatedAt = time.Now().UTC()
+		p.persistBucketLocked(bucket)
+	}
+	p.bus.Publish(events.Event{
+		Type:      events.EventRecover,
+		BucketKey: bucketKey,
+		Message:   "overload probe: recovered",
+	})
+	slog.Info("overload probe: recovered", "bucketKey", bucketKey)
+}
+
+// ExtendOverloadCooldown applies exponential backoff on a still-overloaded bucket.
+// Formula: baseDuration * 2^(consecutiveProbes+1), capped at 30min.
+func (p *Pool) ExtendOverloadCooldown(bucketKey string, baseDuration time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	state, ok := p.overloadBackoff[bucketKey]
+	if !ok {
+		return
+	}
+
+	exponent := state.consecutiveProbes + 1
+	duration := baseDuration
+	for i := 0; i < exponent; i++ {
+		duration *= 2
+		if duration > 30*time.Minute {
+			duration = 30 * time.Minute
+			break
+		}
+	}
+	state.consecutiveProbes++
+
+	bucket, ok := p.buckets[bucketKey]
+	if !ok {
+		return
+	}
+	until := time.Now().Add(duration).UTC()
+	bucket.CooldownUntil = &until
+	bucket.UpdatedAt = time.Now().UTC()
+	p.persistBucketLocked(bucket)
+
+	p.bus.Publish(events.Event{
+		Type:          events.EventOverload,
+		BucketKey:     bucketKey,
+		CooldownUntil: &until,
+		Message:       "overload probe: still overloaded, extending cooldown",
+	})
+	slog.Warn("overload probe: still overloaded, extending cooldown",
+		"bucketKey", bucketKey, "until", until, "probeAttempt", state.consecutiveProbes)
+}
+
+// AnyAccountInBucket returns one active account from the given bucket for probing.
+func (p *Pool) AnyAccountInBucket(bucketKey string) *domain.Account {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	for _, acct := range p.accounts {
+		if p.bucketKeyLocked(acct) == bucketKey && acct.Status == domain.StatusActive {
+			return p.projectAccountLocked(acct)
+		}
+	}
+	return nil
+}
+
+// IsProviderOverloaded returns true if ALL active buckets for a provider are
+// currently in overload state.
+func (p *Pool) IsProviderOverloaded(provider domain.Provider) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	hasActiveBucket := false
+	for _, bucket := range p.buckets {
+		if bucket.Provider != provider {
+			continue
+		}
+		// Only consider buckets that have at least one active account.
+		hasMember := false
+		for _, acct := range p.accounts {
+			if p.bucketKeyLocked(acct) == bucket.BucketKey && acct.Status == domain.StatusActive {
+				hasMember = true
+				break
+			}
+		}
+		if !hasMember {
+			continue
+		}
+		hasActiveBucket = true
+		if !p.isOverloadBucketLocked(bucket.BucketKey) {
+			return false
+		}
+	}
+	return hasActiveBucket
+}

--- a/internal/relay/relay_attempt.go
+++ b/internal/relay/relay_attempt.go
@@ -274,5 +274,9 @@ func (r *Relay) finishRelayFailure(w http.ResponseWriter, drv driver.ExecutionDr
 		drv.WriteUpstreamError(w, state.lastUpstreamStatus, state.lastUpstreamBody, prepared.input.IsStream)
 		return
 	}
+	if r.pool.IsProviderOverloaded(drv.Provider()) {
+		drv.WriteError(w, 529, string(drv.Provider())+" is currently overloaded, please retry later")
+		return
+	}
 	drv.WriteError(w, http.StatusServiceUnavailable, "no available accounts")
 }

--- a/internal/server/server_overload.go
+++ b/internal/server/server_overload.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/yansircc/llm-broker/internal/driver"
+)
+
+func (s *Server) runOverloadRecovery(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.probeOverloadedBuckets(ctx)
+		}
+	}
+}
+
+func (s *Server) probeOverloadedBuckets(ctx context.Context) {
+	ready := s.pool.OverloadedBucketsReady()
+	if len(ready) == 0 {
+		return
+	}
+
+	// Limit concurrent probes.
+	sem := make(chan struct{}, 3)
+	var wg sync.WaitGroup
+
+	for _, info := range ready {
+		acct := s.pool.AnyAccountInBucket(info.BucketKey)
+		if acct == nil {
+			continue
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(bucketKey string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+
+			result, err := s.probeAccount(probeCtx, acct)
+			if err != nil {
+				slog.Warn("overload probe: error", "bucketKey", bucketKey, "error", err)
+				return
+			}
+
+			if result.ClearCooldown {
+				// probeAccount already called pool.ClearCooldown; clear the overload tracking too.
+				s.pool.ClearOverload(bucketKey)
+				return
+			}
+
+			if result.Effect.Kind == driver.EffectOverload {
+				s.pool.ExtendOverloadCooldown(bucketKey, s.cfg.ErrorPause529)
+				return
+			}
+		}(info.BucketKey)
+	}
+
+	wg.Wait()
+}

--- a/internal/server/server_runtime.go
+++ b/internal/server/server_runtime.go
@@ -69,7 +69,7 @@ func (s *Server) runBackgroundJobs(ctx context.Context) {
 
 func (s *Server) runBackgroundJobWorkers(ctx context.Context) {
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		s.pool.RunCleanup(ctx, 5*time.Minute)
@@ -81,6 +81,10 @@ func (s *Server) runBackgroundJobWorkers(ctx context.Context) {
 	go func() {
 		defer wg.Done()
 		s.runRateLimitRefresh(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		s.runOverloadRecovery(ctx)
 	}()
 	wg.Wait()
 }


### PR DESCRIPTION
Closes #14

## Summary

When all accounts for a provider hit HTTP 529 simultaneously, the system enters an infinite cooldown→clear→529 loop. This PR adds two features to break the cycle:

- **Probe-before-recovery**: Pool tracks overloaded buckets in-memory. `cleanup()` skips these buckets instead of auto-clearing them. A server background goroutine probes upstream every 30s; on success it clears the overload, on continued 529 it extends cooldown with exponential backoff (10m → 20m → 30m cap).
- **Friendly client error**: When all provider buckets are overloaded, relay returns HTTP 529 with a clear message (`"claude is currently overloaded, please retry later"`) instead of the confusing 503 `"no available accounts"`.

## Architecture

Follows the existing boundary: Pool owns state, Server owns I/O.

- Pool gets in-memory `overloadBackoff` map — no new DB columns, no provider conditionals in core
- `Observe(EffectOverload)` marks, `Observe(EffectSuccess)` clears
- `cleanup()` Phase 1 & 3 skip overloaded buckets — they cannot re-enter normal scheduling by fixed TTL alone
- `ClearCooldown()` and `StoreTokens()` also clear overload state
- Server's `runOverloadRecovery()` goroutine probes ready buckets (max 3 concurrent, 15s timeout)
- Relay's `finishRelayFailure()` checks `IsProviderOverloaded()` before falling back to 503

## Acceptance criteria mapping (from #14)

| Criterion | How addressed |
|-----------|---------------|
| Bucket does not re-enter candidate set by fixed TTL | `cleanup()` skips overloaded buckets |
| Recovery requires positive upstream evidence | `probeOverloadedBuckets()` must get probe success before `ClearOverload()` |
| Repeated probes increase backoff | `ExtendOverloadCooldown()`: 10m → 20m → 30m cap |
| No provider conditionals in core | All overload logic is generic `EffectOverload` semantics |

## Files changed

| File | Change |
|------|--------|
| `internal/pool/pool.go` | Add `overloadBackoff` field + init |
| `internal/pool/pool_overload.go` | **New** — overload tracking types + methods |
| `internal/pool/pool_observe.go` | Mark/clear in Observe, skip in cleanup |
| `internal/pool/pool_accounts.go` | Clear overload in ClearCooldown + StoreTokens |
| `internal/server/server_overload.go` | **New** — recovery goroutine |
| `internal/server/server_runtime.go` | Wire recovery goroutine |
| `internal/relay/relay_attempt.go` | Friendly 529 in finishRelayFailure |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/pool/...` passes
- [x] `go test ./internal/relay/...` passes
- [x] `go test ./...` full suite passes
- [ ] Deploy to staging, trigger 529 on all accounts, verify:
  - `overload probe: still overloaded, extending cooldown` logs appear with increasing intervals
  - `overload probe: recovered` log appears when upstream recovers
  - `bucket cooldown expired` only fires for non-overload buckets
  - Client receives 529 with friendly message instead of 503