### PR TITLE
Fix blocked accounts being auto-recovered and re-scheduled

### DIFF
--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -148,6 +148,12 @@ func (d *ClaudeDriver) Interpret(statusCode int, headers http.Header, body []byt
 				UpdatedState:  mustMarshalJSON(state),
 			}
 		}
+		return Effect{
+			Kind:          EffectCooldown,
+			Scope:         EffectScopeBucket,
+			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause403),
+			UpdatedState:  mustMarshalJSON(state),
+		}
 
 	case 401:
 		return Effect{

--- a/internal/pool/pool_accounts.go
+++ b/internal/pool/pool_accounts.go
@@ -204,6 +204,43 @@ func (p *Pool) bucketHasMembersLocked(bucketKey string) bool {
 	return false
 }
 
+// RecoverBucket recovers all blocked accounts in the same bucket as accountID.
+// Returns the number of accounts recovered.
+func (p *Pool) RecoverBucket(accountID string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.reloadStateLocked(context.Background()); err != nil {
+		slog.Warn("pool refresh failed", "op", "recover_bucket", "accountId", accountID, "error", err)
+	}
+	acct, ok := p.accounts[accountID]
+	if !ok {
+		return 0
+	}
+	bucketKey := p.bucketKeyLocked(acct)
+	recovered := 0
+	for _, member := range p.accounts {
+		if p.bucketKeyLocked(member) != bucketKey || member.Status != domain.StatusBlocked {
+			continue
+		}
+		member.Status = domain.StatusActive
+		member.ErrorMessage = ""
+		p.persistLocked(member)
+		p.bus.Publish(events.Event{
+			Type: events.EventRecover, AccountID: member.ID,
+			BucketKey: bucketKey,
+			Message:   "blocked account recovered via probe",
+		})
+		slog.Info("blocked account recovered via probe", "accountId", member.ID, "bucketKey", bucketKey)
+		recovered++
+	}
+	if bucket := p.buckets[bucketKey]; bucket != nil && bucket.CooldownUntil != nil {
+		bucket.CooldownUntil = nil
+		bucket.UpdatedAt = time.Now().UTC()
+		p.persistBucketLocked(bucket)
+	}
+	return recovered
+}
+
 func (p *Pool) MarkError(accountID, msg string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/pool/pool_observe.go
+++ b/internal/pool/pool_observe.go
@@ -50,54 +50,11 @@ func (p *Pool) cleanup() {
 
 	now := time.Now()
 
-	// Phase 1: bucket-scoped decisions. Each bucket is visited exactly once.
-	for _, bucket := range p.buckets {
-		if bucket.CooldownUntil != nil && now.After(*bucket.CooldownUntil) {
-			// Check if any member is blocked — if so, defer clearing to
-			// phase 2 so blocked recovery sees the non-nil cooldown.
-			hasBlocked := false
-			for _, acct := range p.accounts {
-				if p.bucketKeyLocked(acct) == bucket.BucketKey && acct.Status == domain.StatusBlocked {
-					hasBlocked = true
-					break
-				}
-			}
-			if !hasBlocked {
-				bucket.CooldownUntil = nil
-				bucket.UpdatedAt = now.UTC()
-				p.persistBucketLocked(bucket)
-				p.bus.Publish(events.Event{
-					Type:      events.EventRecover,
-					BucketKey: bucket.BucketKey,
-					Message:   "cooldown expired",
-				})
-				slog.Info("bucket cooldown expired", "bucketKey", bucket.BucketKey)
-			}
-		}
-	}
-
-	// Phase 2: recover blocked accounts whose bucket cooldown has expired.
-	// This runs after phase 1 so that buckets with blocked members still
-	// have CooldownUntil set (phase 1 skipped clearing them).
-	for _, acct := range p.accounts {
-		if acct.Status == domain.StatusBlocked {
-			cooldownUntil := p.bucketCooldownLocked(acct)
-			if cooldownUntil != nil && now.After(*cooldownUntil) {
-				acct.Status = domain.StatusActive
-				acct.ErrorMessage = ""
-				p.persistLocked(acct)
-				p.bus.Publish(events.Event{
-					Type: events.EventRecover, AccountID: acct.ID,
-					BucketKey: p.bucketKeyLocked(acct),
-					Message:   "blocked account recovered",
-				})
-				slog.Info("blocked account recovered", "accountId", acct.ID)
-			}
-		}
-	}
-
-	// Phase 3: clear bucket cooldowns that were held for blocked recovery,
-	// and enforce exhausted cooldowns on now-available buckets.
+	// Phase 1: clear expired bucket cooldowns unconditionally.
+	// Blocked accounts are NOT auto-recovered — they require manual
+	// admin intervention (set status to active) or a successful probe.
+	// This prevents the ban→recover→pick→ban loop that wastes user requests
+	// when an upstream provider permanently disables an organization.
 	for _, bucket := range p.buckets {
 		if bucket.CooldownUntil != nil && now.After(*bucket.CooldownUntil) {
 			bucket.CooldownUntil = nil
@@ -110,7 +67,10 @@ func (p *Pool) cleanup() {
 			})
 			slog.Info("bucket cooldown expired", "bucketKey", bucket.BucketKey)
 		}
+	}
 
+	// Phase 2: enforce exhausted cooldowns on now-available buckets.
+	for _, bucket := range p.buckets {
 		if bucket.CooldownUntil == nil {
 			// Find any active member to compute exhausted cooldown.
 			for _, acct := range p.accounts {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1066,18 +1066,20 @@ func TestObserve_FullLifecycle_EventNarrative(t *testing.T) {
 	p.persistBucketLocked(bucket)
 	p.cleanup()
 
+	// Blocked accounts must NOT auto-recover. Only bucket cooldown should clear.
+	if got := p.accounts[acct.ID]; got.Status != domain.StatusBlocked {
+		t.Fatalf("blocked account should stay blocked, got %s", got.Status)
+	}
+
 	recent := p.bus.Recent(10)
-	var recoveredAcct, recoveredBucket bool
+	var recoveredBucket bool
 	for _, ev := range recent {
 		if ev.Type == events.EventRecover && ev.AccountID == acct.ID && ev.Message == "blocked account recovered" {
-			recoveredAcct = true
+			t.Fatal("blocked account should not auto-recover")
 		}
 		if ev.Type == events.EventRecover && ev.BucketKey == bk && ev.Message == "cooldown expired" {
 			recoveredBucket = true
 		}
-	}
-	if !recoveredAcct {
-		t.Fatal("missing 'blocked account recovered' event")
 	}
 	if !recoveredBucket {
 		t.Fatal("missing 'cooldown expired' event")
@@ -1194,7 +1196,7 @@ func TestApplyBucketCooldown_NilBucket(t *testing.T) {
 	}
 }
 
-func TestCleanup_SharedBucket_BlockedRecovery(t *testing.T) {
+func TestCleanup_SharedBucket_BlockedStaysBlocked(t *testing.T) {
 	active := &domain.Account{
 		ID: "sbr-active", Email: "a@test.com", Provider: domain.ProviderClaude,
 		Subject: "shared-org", Status: domain.StatusActive, Priority: 50,
@@ -1220,13 +1222,15 @@ func TestCleanup_SharedBucket_BlockedRecovery(t *testing.T) {
 
 	p.cleanup()
 
-	if p.accounts["sbr-blocked"].Status != domain.StatusActive {
-		t.Fatalf("blocked account should have recovered, got status %s", p.accounts["sbr-blocked"].Status)
+	// Blocked account must stay blocked — no auto-recovery.
+	if p.accounts["sbr-blocked"].Status != domain.StatusBlocked {
+		t.Fatalf("blocked account should stay blocked, got status %s", p.accounts["sbr-blocked"].Status)
 	}
-	if p.accounts["sbr-blocked"].ErrorMessage != "" {
-		t.Fatalf("error message should be cleared, got %q", p.accounts["sbr-blocked"].ErrorMessage)
+	if p.accounts["sbr-blocked"].ErrorMessage != "banned" {
+		t.Fatalf("error message should be preserved, got %q", p.accounts["sbr-blocked"].ErrorMessage)
 	}
 
+	// Bucket cooldown should still clear so other accounts in the bucket can be used.
 	bucket = p.buckets[bucketKey]
 	if bucket == nil {
 		t.Fatal("bucket gone after cleanup")
@@ -1236,18 +1240,14 @@ func TestCleanup_SharedBucket_BlockedRecovery(t *testing.T) {
 	}
 
 	all := p.bus.Recent(10)
-	hasRecover := false
 	hasExpiry := false
 	for _, ev := range all {
 		if ev.Type == events.EventRecover && ev.AccountID == "sbr-blocked" {
-			hasRecover = true
+			t.Fatal("blocked account should not emit recovery event")
 		}
 		if ev.Type == events.EventRecover && ev.Message == "cooldown expired" {
 			hasExpiry = true
 		}
-	}
-	if !hasRecover {
-		t.Fatal("missing 'blocked account recovered' event")
 	}
 	if !hasExpiry {
 		t.Fatal("missing 'cooldown expired' event")

--- a/internal/server/admin_accounts.go
+++ b/internal/server/admin_accounts.go
@@ -291,6 +291,8 @@ func (s *Server) handleTestAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	wasBlocked := acct.Status == domain.StatusBlocked
+
 	start := time.Now()
 	_, err := s.probeAccount(r.Context(), acct)
 	latencyMs := time.Since(start).Milliseconds()
@@ -298,6 +300,17 @@ func (s *Server) handleTestAccount(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, TestAccountResult{LatencyMs: latencyMs, Error: err.Error()})
 		return
 	}
+
+	// If the account was blocked and the probe succeeded, recover it.
+	if wasBlocked {
+		_ = s.pool.Update(id, func(a *domain.Account) {
+			a.Status = domain.StatusActive
+			a.ErrorMessage = ""
+		})
+		s.pool.ClearCooldown(id)
+		slog.Info("blocked account recovered via successful probe", "id", id)
+	}
+
 	writeJSON(w, http.StatusOK, TestAccountResult{OK: true, LatencyMs: latencyMs})
 }
 

--- a/internal/server/admin_accounts.go
+++ b/internal/server/admin_accounts.go
@@ -301,14 +301,13 @@ func (s *Server) handleTestAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the account was blocked and the probe succeeded, recover it.
+	// If the account was blocked and the probe succeeded, recover all
+	// blocked accounts in the same bucket. The ban is bucket-scoped
+	// (e.g. entire org disabled), so a successful probe proves the
+	// whole bucket is usable again.
 	if wasBlocked {
-		_ = s.pool.Update(id, func(a *domain.Account) {
-			a.Status = domain.StatusActive
-			a.ErrorMessage = ""
-		})
-		s.pool.ClearCooldown(id)
-		slog.Info("blocked account recovered via successful probe", "id", id)
+		n := s.pool.RecoverBucket(id)
+		slog.Info("blocked bucket recovered via successful probe", "id", id, "recovered", n)
 	}
 
 	writeJSON(w, http.StatusOK, TestAccountResult{OK: true, LatencyMs: latencyMs})


### PR DESCRIPTION
## Summary

- Blocked accounts (`EffectBlock`) were auto-recovered to active after a 30-minute bucket cooldown expired, creating an infinite **ban → recover → pick → ban** loop that wasted user requests on permanently disabled upstream accounts
- Remove cleanup Phase 2 that auto-recovered blocked accounts; `StatusBlocked` is now an absorbing state requiring manual admin intervention or a successful probe to recover
- Clear expired bucket cooldowns unconditionally so other accounts in the same bucket remain usable
- Add probe-based recovery: `handleTestAccount` recovers blocked accounts when the upstream probe succeeds
- Fix `claude.go` case 400: non-ban 400 responses now return `EffectCooldown` instead of falling through to `EffectSuccess`

## Context

A Claude account ("Kelvis") received "organization has been disabled" from upstream at 03:00 UTC+8. The cleanup goroutine auto-recovered it every 30 minutes, causing 10+ ban cycles over 6.5 hours and failing 12 user requests before the admin manually deleted the account.

## Recovery paths after this fix

| Path | How |
|------|-----|
| Admin sets status to active | Web UI → account → set active |
| Probe succeeds | Web UI → account → test (auto-recovers if probe OK) |

## Test plan

- [x] `TestObserve_FullLifecycle_EventNarrative` — verifies blocked account stays blocked after cleanup
- [x] `TestCleanup_SharedBucket_BlockedStaysBlocked` — verifies bucket cooldown clears while blocked account stays blocked
- [x] All existing tests pass (`go test ./...`)