### PR TITLE
Match Claude OAuth transport fingerprint

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -165,6 +165,7 @@ func main() {
 		MaxRetryAccounts:  cfg.MaxRetryAccounts,
 		SessionBindingTTL: cfg.SessionBindingTTL,
 		CellErrorPause:    cfg.CellErrorPause,
+		TraceCompat:       cfg.TraceCompat,
 	}, transportPool, bus, executionDrivers)
 
 	// Start server

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,8 @@ type Config struct {
 	CompatMaxConcurrent        int
 
 	// Logging
-	LogLevel string
+	LogLevel    string
+	TraceCompat bool
 
 	// Runtime
 	BackgroundJobsMode       string
@@ -100,7 +101,8 @@ func Load() *Config {
 		CompatMaxRequestsPerMinute: envInt("COMPAT_MAX_REQUESTS_PER_MINUTE", 6),
 		CompatMaxConcurrent:        envInt("COMPAT_MAX_CONCURRENT", 1),
 
-		LogLevel: envOr("LOG_LEVEL", "info"),
+		LogLevel:    envOr("LOG_LEVEL", "info"),
+		TraceCompat: envBool("TRACE_COMPAT", false),
 
 		BackgroundJobsMode:       envOr("BACKGROUND_JOBS_MODE", "all"),
 		BackgroundLeaderLockPath: envOr("BACKGROUND_LEADER_LOCK_PATH", "/var/run/llm-broker/background.lock"),
@@ -157,6 +159,18 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 	if v := os.Getenv(key); v != "" {
 		if ms, err := strconv.Atoi(v); err == nil {
 			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	if v := os.Getenv(key); v != "" {
+		switch v {
+		case "1", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+			return true
+		case "0", "false", "FALSE", "False", "no", "NO", "off", "OFF":
+			return false
 		}
 	}
 	return fallback

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -44,7 +44,7 @@ func (d *ClaudeDriver) BuildRequest(ctx context.Context, input *RelayInput, acct
 		return nil, fmt.Errorf("body re-parse: %w", err)
 	}
 
-	result, err := d.transformer.Transform(ctx, body, input.Headers, acct)
+	result, err := d.transformer.Transform(ctx, body, input.Headers, acct, input.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("transform identity: %w", err)
 	}

--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -58,7 +58,7 @@ func (d *ClaudeDriver) BuildRequest(ctx context.Context, input *RelayInput, acct
 	if input.IsCountTokens {
 		apiURL += "/count_tokens"
 	}
-	upstreamURL, err := appendRawQuery(apiURL, input.RawQuery)
+	upstreamURL, err := appendRawQuery(apiURL, ensureBetaParam(input.RawQuery))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/driver/http_helpers.go
+++ b/internal/driver/http_helpers.go
@@ -45,6 +45,18 @@ func appendRawQuery(rawURL, rawQuery string) (string, error) {
 	return u.String(), nil
 }
 
+// ensureBetaParam adds beta=true to the query string if not already present.
+// Claude Code always sends this parameter; its absence is a fingerprint signal.
+func ensureBetaParam(rawQuery string) string {
+	if strings.Contains(rawQuery, "beta=true") {
+		return rawQuery
+	}
+	if rawQuery == "" {
+		return "beta=true"
+	}
+	return rawQuery + "&beta=true"
+}
+
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -54,6 +54,7 @@ type RelayInput struct {
 	Path          string
 	RawQuery      string
 	Model         string
+	UserID        string // broker user ID, used to synthesize metadata.user_id when absent
 	IsStream      bool
 	IsCountTokens bool
 }

--- a/internal/identity/headers.go
+++ b/internal/identity/headers.go
@@ -50,6 +50,7 @@ func SetRequiredHeaders(h http.Header, accessToken, apiVersion, betaHeader strin
 		h.Set("anthropic-beta", mergedBeta)
 	}
 	h.Set("Content-Type", "application/json")
+	h.Set("User-Agent", "claude-cli/2.2.0 (external, cli)")
 }
 
 func mergeBetaHeaders(clientBeta, relayBeta string) string {

--- a/internal/identity/transform.go
+++ b/internal/identity/transform.go
@@ -41,6 +41,7 @@ func (t *Transformer) Transform(
 	body map[string]interface{},
 	reqHeaders http.Header,
 	acct *domain.Account,
+	brokerUserID string,
 ) (*TransformResult, error) {
 	result := &TransformResult{
 		Body:    body,
@@ -53,11 +54,20 @@ func (t *Transformer) Transform(
 	// 2. Enforce cache_control compliance (max N blocks, strip TTL)
 	t.enforceCacheControl(body)
 
-	// 3. Rewrite metadata.user_id
+	// 3. Rewrite or inject metadata.user_id
 	accountUUID := acct.IdentityString("account_uuid")
-	if metadata, ok := body["metadata"].(map[string]interface{}); ok {
+	metadata, hasMeta := body["metadata"].(map[string]interface{})
+	if hasMeta {
 		if origUserID, ok := metadata["user_id"].(string); ok {
 			metadata["user_id"] = RewriteUserID(origUserID, acct.ID, accountUUID)
+		}
+	} else {
+		// Inject synthetic Claude Code identity for non-native clients.
+		// Session tail is keyed on (account, broker_user) so each broker
+		// user gets a stable, unique session per Claude account.
+		sessionTail := "compat-" + brokerUserID
+		body["metadata"] = map[string]interface{}{
+			"user_id": buildUserID(acct.ID, accountUUID, sessionTail),
 		}
 	}
 

--- a/internal/identity/transform.go
+++ b/internal/identity/transform.go
@@ -56,18 +56,21 @@ func (t *Transformer) Transform(
 
 	// 3. Rewrite or inject metadata.user_id
 	accountUUID := acct.IdentityString("account_uuid")
+	sessionTail := "compat-" + brokerUserID
+	syntheticUserID := buildUserID(acct.ID, accountUUID, sessionTail)
+
 	metadata, hasMeta := body["metadata"].(map[string]interface{})
 	if hasMeta {
 		if origUserID, ok := metadata["user_id"].(string); ok {
 			metadata["user_id"] = RewriteUserID(origUserID, acct.ID, accountUUID)
+		} else {
+			// metadata exists but user_id is missing — inject it.
+			metadata["user_id"] = syntheticUserID
 		}
 	} else {
-		// Inject synthetic Claude Code identity for non-native clients.
-		// Session tail is keyed on (account, broker_user) so each broker
-		// user gets a stable, unique session per Claude account.
-		sessionTail := "compat-" + brokerUserID
+		// No metadata at all — inject synthetic Claude Code identity.
 		body["metadata"] = map[string]interface{}{
-			"user_id": buildUserID(acct.ID, accountUUID, sessionTail),
+			"user_id": syntheticUserID,
 		}
 	}
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -24,6 +24,7 @@ type Config struct {
 	MaxRetryAccounts  int
 	SessionBindingTTL time.Duration
 	CellErrorPause    time.Duration
+	TraceCompat       bool
 }
 
 type Relay struct {

--- a/internal/relay/relay_attempt.go
+++ b/internal/relay/relay_attempt.go
@@ -81,10 +81,25 @@ func (r *Relay) executeRelayAttempt(
 		state.lastErr = fmt.Errorf("build request: %w", err)
 		return relayAttemptStop
 	}
+	if r.shouldTraceCompat(prepared) {
+		upstreamBody, snapErr := snapshotRequestBody(upReq)
+		if snapErr != nil {
+			slog.Warn("compat trace request snapshot failed",
+				"traceId", compatTraceID(prepared),
+				"clientPath", safeInputPath(prepared),
+				"upstreamURL", safeRequestURL(upReq),
+				"error", snapErr,
+			)
+		}
+		r.logCompatTraceRequest(prepared, acct, attempt, upReq, upstreamBody)
+	}
 
 	attemptStartedAt := time.Now()
 	resp, err := r.transport.ClientForAccount(acct).Do(upReq)
 	if err != nil {
+		if r.shouldTraceCompat(prepared) {
+			r.logCompatTraceTransportError(prepared, acct, attempt, upReq, err)
+		}
 		if acct.CellID != "" && r.cfg.CellErrorPause > 0 && neterr.IsTransport(err) {
 			r.pool.CooldownCell(acct.CellID, time.Now().Add(r.cfg.CellErrorPause), fmt.Sprintf("relay transport error on account %s: %v", acct.Email, err))
 		}
@@ -111,8 +126,32 @@ func (r *Relay) executeRelayAttempt(
 		return relayAttemptContinue
 	}
 
+	var tracedRespBody []byte
+	if r.shouldTraceCompat(prepared) {
+		if prepared.input.IsStream {
+			r.logCompatTraceResponse(prepared, acct, attempt, upReq, resp, nil)
+		} else {
+			body, snapErr := snapshotResponseBody(resp)
+			if snapErr != nil {
+				slog.Warn("compat trace response snapshot failed",
+					"traceId", compatTraceID(prepared),
+					"clientPath", safeInputPath(prepared),
+					"upstreamURL", safeRequestURL(upReq),
+					"status", resp.StatusCode,
+					"error", snapErr,
+				)
+			} else {
+				tracedRespBody = body
+				r.logCompatTraceResponse(prepared, acct, attempt, upReq, resp, tracedRespBody)
+			}
+		}
+	}
+
 	if drv.ShouldRetry(resp.StatusCode) && attempt < r.cfg.MaxRetryAccounts {
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody := tracedRespBody
+		if errBody == nil {
+			errBody, _ = io.ReadAll(resp.Body)
+		}
 		resp.Body.Close()
 
 		r.logRequestAsync(&domain.RequestLog{
@@ -158,7 +197,10 @@ func (r *Relay) executeRelayAttempt(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody := tracedRespBody
+		if errBody == nil {
+			errBody, _ = io.ReadAll(resp.Body)
+		}
 		resp.Body.Close()
 
 		r.logRequestAsync(&domain.RequestLog{

--- a/internal/relay/relay_attempt_test.go
+++ b/internal/relay/relay_attempt_test.go
@@ -21,10 +21,13 @@ import (
 )
 
 type relayTestDriver struct {
-	provider        domain.Provider
-	interpretCalls  []int
-	interpretBodies [][]byte
-	interpretFn     func(statusCode int, body []byte) driver.Effect
+	provider            domain.Provider
+	interpretCalls      []int
+	interpretBodies     [][]byte
+	interpretFn         func(statusCode int, body []byte) driver.Effect
+	buildRequestBody    string
+	buildRequestURL     string
+	buildRequestHeaders http.Header
 }
 
 func (d *relayTestDriver) Provider() domain.Provider { return d.provider }
@@ -32,7 +35,24 @@ func (d *relayTestDriver) Provider() domain.Provider { return d.provider }
 func (d *relayTestDriver) Plan(_ *driver.RelayInput) driver.RelayPlan { return driver.RelayPlan{} }
 
 func (d *relayTestDriver) BuildRequest(ctx context.Context, _ *driver.RelayInput, _ *domain.Account, _ string) (*http.Request, error) {
-	return http.NewRequestWithContext(ctx, http.MethodPost, "https://upstream.test/v1/messages", strings.NewReader(`{}`))
+	url := d.buildRequestURL
+	if url == "" {
+		url = "https://upstream.test/v1/messages"
+	}
+	body := d.buildRequestBody
+	if body == "" {
+		body = `{}`
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for key, vals := range d.buildRequestHeaders {
+		for _, val := range vals {
+			req.Header.Add(key, val)
+		}
+	}
+	return req, nil
 }
 
 func (d *relayTestDriver) Interpret(statusCode int, _ http.Header, body []byte, _ string, _ json.RawMessage) driver.Effect {
@@ -514,5 +534,146 @@ func TestExecuteRelayAttemptPassesBodyToInterpretOnNonRetriable400(t *testing.T)
 	}
 	if !strings.Contains(recorder.Body.String(), "organization has been disabled") {
 		t.Fatalf("response body = %q, want upstream body", recorder.Body.String())
+	}
+}
+
+func TestExecuteRelayAttemptLogsCompatTraceEnvelope(t *testing.T) {
+	mockStore := store.NewMockStore()
+	account := &domain.Account{
+		ID:        "acct-trace",
+		Email:     "trace@example.com",
+		Provider:  domain.ProviderClaude,
+		Status:    domain.StatusActive,
+		Subject:   "subject-trace",
+		CellID:    "cell-compat",
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := mockStore.SaveAccount(context.Background(), account); err != nil {
+		t.Fatalf("SaveAccount: %v", err)
+	}
+	if err := mockStore.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-compat",
+		Name:      "compat",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "10.0.0.3", Port: 11082},
+		Labels:    map[string]string{"lane": "compat"},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveEgressCell: %v", err)
+	}
+	if err := mockStore.SaveQuotaBucket(context.Background(), &domain.QuotaBucket{
+		BucketKey: "claude:subject-trace",
+		Provider:  domain.ProviderClaude,
+		StateJSON: "{}",
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveQuotaBucket: %v", err)
+	}
+
+	bus := events.NewBus(16)
+	p, err := pool.New(mockStore, bus)
+	if err != nil {
+		t.Fatalf("pool.New: %v", err)
+	}
+
+	driverStub := &relayTestDriver{
+		provider:         domain.ProviderClaude,
+		buildRequestURL:  "https://api.anthropic.com/v1/messages",
+		buildRequestBody: `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`,
+		buildRequestHeaders: http.Header{
+			"Content-Type":  []string{"application/json"},
+			"Authorization": []string{"Bearer secret-upstream"},
+			"User-Agent":    []string{"claude-cli/2.2.0"},
+		},
+	}
+	transport := relayTestTransport{
+		client: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				headers := make(http.Header)
+				headers.Set("request-id", "req_trace")
+				headers.Set("Content-Type", "application/json")
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Header:     headers,
+					Body: io.NopCloser(strings.NewReader(
+						`{"type":"error","error":{"type":"invalid_request_error","message":"Error"}}`,
+					)),
+				}, nil
+			}),
+		},
+	}
+	relaySvc := New(
+		p,
+		relayTestTokenProvider{},
+		mockStore,
+		Config{
+			MaxRetryAccounts: 1,
+			TraceCompat:      true,
+		},
+		transport,
+		bus,
+		map[domain.Provider]driver.ExecutionDriver{domain.ProviderClaude: driverStub},
+	)
+
+	capture := &captureHandler{}
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	defer slog.SetDefault(oldLogger)
+
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Authorization", "Bearer secret-client")
+	headers.Set("X-Broker-Compat-Trace-Id", "compat-42")
+	prepared := &preparedRelayRequest{
+		keyInfo: &auth.KeyInfo{ID: "user-trace", Name: "trace"},
+		surface: domain.SurfaceCompat,
+		input: &driver.RelayInput{
+			Headers: headers,
+			Path:    "/compat/v1/chat/completions",
+			Model:   "claude-sonnet-4-6",
+			RawBody: []byte(`{"model":"claude/claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`),
+		},
+	}
+
+	outcome := relaySvc.executeRelayAttempt(
+		context.Background(),
+		httptest.NewRecorder(),
+		driverStub,
+		prepared,
+		newRelayAttemptState(),
+		0,
+	)
+	if outcome != relayAttemptDone {
+		t.Fatalf("executeRelayAttempt outcome = %v, want %v", outcome, relayAttemptDone)
+	}
+
+	reqRecord := capture.find("compat upstream request")
+	if reqRecord == nil {
+		t.Fatal("missing compat upstream request log record")
+	}
+	if reqRecord.attrs["traceId"] != "compat-42" {
+		t.Fatalf("traceId = %#v, want compat-42", reqRecord.attrs["traceId"])
+	}
+	if reqRecord.attrs["upstreamBody"] != `{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}` {
+		t.Fatalf("upstreamBody = %#v", reqRecord.attrs["upstreamBody"])
+	}
+	headersAny, ok := reqRecord.attrs["upstreamHeaders"].(map[string]string)
+	if !ok {
+		t.Fatalf("upstreamHeaders type = %T, want map[string]string", reqRecord.attrs["upstreamHeaders"])
+	}
+	if _, exists := headersAny["Authorization"]; exists {
+		t.Fatalf("authorization header should not be logged: %#v", headersAny)
+	}
+
+	respRecord := capture.find("compat upstream response")
+	if respRecord == nil {
+		t.Fatal("missing compat upstream response log record")
+	}
+	if respRecord.attrs["traceId"] != "compat-42" {
+		t.Fatalf("response traceId = %#v, want compat-42", respRecord.attrs["traceId"])
+	}
+	if respRecord.attrs["responseBody"] != `{"type":"error","error":{"type":"invalid_request_error","message":"Error"}}` {
+		t.Fatalf("responseBody = %#v", respRecord.attrs["responseBody"])
 	}
 }

--- a/internal/relay/relay_request.go
+++ b/internal/relay/relay_request.go
@@ -94,6 +94,7 @@ func (r *Relay) parseRelayInput(w http.ResponseWriter, req *http.Request, drv dr
 		Path:     req.URL.Path,
 		RawQuery: req.URL.RawQuery,
 		Model:    model,
+		UserID:   keyInfo.ID,
 	}
 	plan := drv.Plan(input)
 	input.IsStream = plan.IsStream

--- a/internal/relay/relay_trace.go
+++ b/internal/relay/relay_trace.go
@@ -1,0 +1,186 @@
+package relay
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/yansircc/llm-broker/internal/domain"
+)
+
+const compatTraceBodyLimit = 64 << 10
+
+func (r *Relay) shouldTraceCompat(prepared *preparedRelayRequest) bool {
+	return r != nil && r.cfg.TraceCompat && prepared != nil && prepared.surface == domain.SurfaceCompat
+}
+
+func snapshotRequestBody(req *http.Request) ([]byte, error) {
+	if req == nil || req.Body == nil {
+		return nil, nil
+	}
+	if req.GetBody != nil {
+		rc, err := req.GetBody()
+		if err == nil {
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	return body, nil
+}
+
+func snapshotResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	return body, nil
+}
+
+func (r *Relay) logCompatTraceRequest(prepared *preparedRelayRequest, _ *domain.Account, attempt int, upReq *http.Request, upstreamBody []byte) {
+	upstreamText, upstreamTruncated := formatTraceBody(upstreamBody)
+
+	slog.Info("compat upstream request",
+		"traceId", compatTraceID(prepared),
+		"attempt", attempt+1,
+		"clientPath", safeInputPath(prepared),
+		"upstreamURL", safeRequestURL(upReq),
+		"upstreamHeaders", traceRequestHeaders(upReq.Header),
+		"upstreamBody", upstreamText,
+		"upstreamBodyBytes", len(upstreamBody),
+		"upstreamBodyTruncated", upstreamTruncated,
+	)
+}
+
+func (r *Relay) logCompatTraceResponse(prepared *preparedRelayRequest, _ *domain.Account, attempt int, upReq *http.Request, resp *http.Response, respBody []byte) {
+	bodyText, bodyTruncated := formatTraceBody(respBody)
+	statusCode := 0
+	headers := http.Header(nil)
+	isStream := false
+	if resp != nil {
+		statusCode = resp.StatusCode
+		headers = resp.Header
+		isStream = prepared != nil && prepared.input != nil && prepared.input.IsStream
+	}
+
+	slog.Info("compat upstream response",
+		"traceId", compatTraceID(prepared),
+		"attempt", attempt+1,
+		"clientPath", safeInputPath(prepared),
+		"upstreamURL", safeRequestURL(upReq),
+		"status", statusCode,
+		"stream", isStream,
+		"responseHeaders", traceResponseHeaders(headers),
+		"responseBody", bodyText,
+		"responseBodyBytes", len(respBody),
+		"responseBodyTruncated", bodyTruncated,
+	)
+}
+
+func (r *Relay) logCompatTraceTransportError(prepared *preparedRelayRequest, _ *domain.Account, attempt int, upReq *http.Request, err error) {
+	slog.Info("compat upstream transport error",
+		"traceId", compatTraceID(prepared),
+		"attempt", attempt+1,
+		"clientPath", safeInputPath(prepared),
+		"upstreamURL", safeRequestURL(upReq),
+		"error", err,
+	)
+}
+
+func formatTraceBody(body []byte) (string, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+
+	formatted := trimmed
+	if bytes.HasPrefix(trimmed, []byte("{")) || bytes.HasPrefix(trimmed, []byte("[")) {
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, trimmed); err == nil {
+			formatted = compact.Bytes()
+		}
+	}
+
+	if len(formatted) <= compatTraceBodyLimit {
+		return string(formatted), false
+	}
+	return string(formatted[:compatTraceBodyLimit]) + "...<truncated>", true
+}
+
+func traceRequestHeaders(h http.Header) map[string]string {
+	return traceHeaders(h, func(lower string) bool {
+		return lower == "accept" ||
+			lower == "content-type" ||
+			lower == "user-agent" ||
+			lower == "x-app" ||
+			lower == "x-stainless-retry-count" ||
+			lower == "anthropic-version" ||
+			lower == "anthropic-beta" ||
+			lower == "anthropic-dangerous-direct-browser-access" ||
+			strings.HasPrefix(lower, "x-stainless-")
+	})
+}
+
+func traceResponseHeaders(h http.Header) map[string]string {
+	return traceHeaders(h, func(lower string) bool {
+		return lower == "content-type" ||
+			lower == "retry-after" ||
+			lower == "x-request-id" ||
+			lower == "request-id" ||
+			lower == "cf-ray" ||
+			strings.HasPrefix(lower, "anthropic-")
+	})
+}
+
+func traceHeaders(h http.Header, allow func(string) bool) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for key, vals := range h {
+		lower := strings.ToLower(key)
+		if !allow(lower) || len(vals) == 0 {
+			continue
+		}
+		out[key] = strings.Join(vals, ", ")
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func safeInputPath(prepared *preparedRelayRequest) string {
+	if prepared == nil || prepared.input == nil {
+		return ""
+	}
+	return prepared.input.Path
+}
+
+func compatTraceID(prepared *preparedRelayRequest) string {
+	if prepared == nil || prepared.input == nil {
+		return ""
+	}
+	return prepared.input.Headers.Get("X-Broker-Compat-Trace-Id")
+}
+
+func safeRequestURL(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	return req.URL.String()
+}

--- a/internal/server/compat_openai_chat.go
+++ b/internal/server/compat_openai_chat.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,8 +57,14 @@ func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	}
 	defer releaseCompatSlot()
 
+	rawBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCompatOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
+		return
+	}
+
 	var req compatOpenAIChatRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(rawBody)).Decode(&req); err != nil {
 		writeCompatOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
 		return
 	}
@@ -71,6 +79,12 @@ func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *htt
 		return
 	}
 
+	traceID := ""
+	if s.cfg != nil && s.cfg.TraceCompat {
+		traceID = s.nextCompatTraceID()
+		s.logCompatTranslationTrace(traceID, rawBody, r.URL.Path, target.relayPath, target.upstreamBody)
+	}
+
 	relayReq := r.Clone(r.Context())
 	relayURL := *r.URL
 	relayURL.Path = target.relayPath
@@ -81,6 +95,9 @@ func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	relayReq.ContentLength = int64(len(target.upstreamBody))
 	relayReq.Header = r.Header.Clone()
 	relayReq.Header.Set("Content-Type", "application/json")
+	if traceID != "" {
+		relayReq.Header.Set("X-Broker-Compat-Trace-Id", traceID)
+	}
 	if target.stream {
 		relayReq.Header.Set("Accept", "text/event-stream")
 	}
@@ -226,4 +243,31 @@ func compatRequestBodyLimitBytes(cfg *config.Config) int64 {
 		return int64(cfg.MaxRequestBodyMB) << 20
 	}
 	return int64(compatDefaultRequestBodyMB) << 20
+}
+
+func (s *Server) nextCompatTraceID() string {
+	return "compat-" + strconv.FormatUint(s.requestSeq.Add(1), 10)
+}
+
+func (s *Server) logCompatTranslationTrace(
+	traceID string,
+	clientBody []byte,
+	clientPath string,
+	relayPath string,
+	translatedBody []byte,
+) {
+	clientText, clientTruncated := formatCompatTraceBody(clientBody)
+	translatedText, translatedTruncated := formatCompatTraceBody(translatedBody)
+
+	slog.Info("compat translation",
+		"traceId", traceID,
+		"clientPath", clientPath,
+		"relayPath", relayPath,
+		"clientBody", clientText,
+		"clientBodyBytes", len(clientBody),
+		"clientBodyTruncated", clientTruncated,
+		"translatedBody", translatedText,
+		"translatedBodyBytes", len(translatedBody),
+		"translatedBodyTruncated", translatedTruncated,
+	)
 }

--- a/internal/server/compat_openai_chat_test.go
+++ b/internal/server/compat_openai_chat_test.go
@@ -376,7 +376,7 @@ func TestHandleCompatListModels(t *testing.T) {
 func TestHandleCompatOpenAIChatCompletions_MinimalLoop(t *testing.T) {
 	upstreamClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != "https://claude.example/v1/messages" {
+			if req.URL.String() != "https://claude.example/v1/messages?beta=true" {
 				t.Fatalf("upstream URL = %q", req.URL.String())
 			}
 			if req.Header.Get("Authorization") != "Bearer test-token" {
@@ -470,7 +470,7 @@ func TestHandleCompatOpenAIChatCompletions_MinimalLoop(t *testing.T) {
 func TestHandleCompatOpenAIChatCompletions_StreamLoop(t *testing.T) {
 	upstreamClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != "https://claude.example/v1/messages" {
+			if req.URL.String() != "https://claude.example/v1/messages?beta=true" {
 				t.Fatalf("upstream URL = %q", req.URL.String())
 			}
 			if req.Header.Get("Accept") != "text/event-stream" {

--- a/internal/server/compat_openai_chat_test.go
+++ b/internal/server/compat_openai_chat_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -805,6 +807,61 @@ func TestHandleCompatOpenAIChatCompletions_RateLimited(t *testing.T) {
 	}
 }
 
+func TestHandleCompatOpenAIChatCompletions_TraceLogsRawClientBody(t *testing.T) {
+	upstreamClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			respBody := `{
+				"id":"msg_compat_trace_1",
+				"model":"claude-sonnet-4-5",
+				"stop_reason":"end_turn",
+				"content":[{"type":"text","text":"compat ok"}]
+			}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+			}, nil
+		}),
+	}
+	srv := newCompatTestServer(t, upstreamClient)
+	srv.cfg.TraceCompat = true
+
+	logs := &serverCaptureHandler{}
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(logs))
+	defer slog.SetDefault(oldLogger)
+
+	reqBody := `{
+		"model":"claude/claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}],
+		"reasoning_effort":"max"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/compat/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), auth.KeyInfoKey, &auth.KeyInfo{ID: "user-1", Name: "test"})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	srv.handleCompatOpenAIChatCompletions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	record := logs.find("compat translation")
+	if record == nil {
+		t.Fatal("missing compat translation log record")
+	}
+	clientBody, _ := record.attrs["clientBody"].(string)
+	if !strings.Contains(clientBody, `"reasoning_effort":"max"`) {
+		t.Fatalf("clientBody = %q, want raw compat envelope field", clientBody)
+	}
+	translatedBody, _ := record.attrs["translatedBody"].(string)
+	if strings.Contains(translatedBody, "reasoning_effort") {
+		t.Fatalf("translatedBody = %q, unexpected passthrough field", translatedBody)
+	}
+}
+
 func newCompatTestServer(t *testing.T, upstreamClient *http.Client) *Server {
 	return newCompatMultiProviderTestServer(t, map[domain.Provider]*http.Client{
 		domain.ProviderClaude: upstreamClient,
@@ -943,4 +1000,69 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+type serverCapturedRecord struct {
+	msg   string
+	attrs map[string]any
+}
+
+type serverCaptureHandler struct {
+	mu      sync.Mutex
+	records []serverCapturedRecord
+}
+
+func (h *serverCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *serverCaptureHandler) Handle(_ context.Context, record slog.Record) error {
+	captured := serverCapturedRecord{
+		msg:   record.Message,
+		attrs: make(map[string]any),
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		captured.attrs[attr.Key] = serverValueAny(attr.Value)
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, captured)
+	return nil
+}
+
+func (h *serverCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *serverCaptureHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *serverCaptureHandler) find(msg string) *serverCapturedRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.records {
+		if h.records[i].msg == msg {
+			record := h.records[i]
+			return &record
+		}
+	}
+	return nil
+}
+
+func serverValueAny(v slog.Value) any {
+	switch v.Kind() {
+	case slog.KindString:
+		return v.String()
+	case slog.KindInt64:
+		return v.Int64()
+	case slog.KindUint64:
+		return v.Uint64()
+	case slog.KindBool:
+		return v.Bool()
+	case slog.KindFloat64:
+		return v.Float64()
+	case slog.KindDuration:
+		return v.Duration()
+	case slog.KindTime:
+		return v.Time()
+	default:
+		return v.Any()
+	}
 }

--- a/internal/server/compat_trace.go
+++ b/internal/server/compat_trace.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+const compatTraceBodyLimit = 64 << 10
+
+func formatCompatTraceBody(body []byte) (string, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+
+	formatted := trimmed
+	if bytes.HasPrefix(trimmed, []byte("{")) || bytes.HasPrefix(trimmed, []byte("[")) {
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, trimmed); err == nil {
+			formatted = compact.Bytes()
+		}
+	}
+
+	if len(formatted) <= compatTraceBodyLimit {
+		return string(formatted), false
+	}
+	return string(formatted[:compatTraceBodyLimit]) + "...<truncated>", true
+}


### PR DESCRIPTION
## Summary

This PR is now the transport/fingerprint half of the original fix.

The request-envelope workarounds were split into #19 so this PR can stay focused on transport-level compatibility.

## Changes

- inject synthetic `metadata.user_id` for non-Claude-Code clients, including the case where `metadata` exists but `user_id` is missing
- add `?beta=true` on Claude upstream requests
- override `User-Agent` to the Claude CLI fingerprint
- add optional compat trace logging (`TRACE_COMPAT`) for client body, translated body, and upstream response capture

## Explicitly not in this PR

Moved to #19:

- Claude system prompt signature injection
- Claude compat `system` / `developer` envelope translation
- compat semantic handling for sampling controls

## Verification

- `go test ./internal/server ./internal/identity ./internal/relay ./internal/driver`
