### PR TITLE
Fix Claude OAuth request envelopes

### DIFF
--- a/internal/identity/transform.go
+++ b/internal/identity/transform.go
@@ -48,13 +48,17 @@ func (t *Transformer) Transform(
 		Headers: FilterHeaders(reqHeaders),
 	}
 
-	// 1. Strip billing headers from system prompt
+	// 1. Ensure system prompt starts with the Claude Code signature Anthropic expects for OAuth traffic.
+	ensureClaudeCodeSystemPrefix(body)
+
+	// 2. Strip billing headers from system prompt
 	t.stripBillingHeaders(body)
 
-	// 2. Enforce cache_control compliance (max N blocks, strip TTL)
+	// 3. Enforce cache_control compliance (max N blocks, strip TTL)
 	t.enforceCacheControl(body)
 
-	// 3. Rewrite or inject metadata.user_id
+	// 4. Rewrite metadata.user_id
+	// Keep or inject metadata.user_id for sticky Claude session identity.
 	accountUUID := acct.IdentityString("account_uuid")
 	sessionTail := "compat-" + brokerUserID
 	syntheticUserID := buildUserID(acct.ID, accountUUID, sessionTail)
@@ -74,10 +78,10 @@ func (t *Transformer) Transform(
 		}
 	}
 
-	// 4. Compute session hash
+	// 5. Compute session hash
 	result.SessionHash = t.computeSessionHashFromBody(body)
 
-	// 5. Bind/restore stainless headers
+	// 6. Bind/restore stainless headers
 	RemoveAllStainless(result.Headers)
 	if err := t.stainless.BindStainlessFromRequest(ctx, acct.ID, reqHeaders, result.Headers); err != nil {
 		return nil, err
@@ -220,4 +224,31 @@ func computeSessionHash(userID, systemPrompt, firstMessage string) string {
 		return hex.EncodeToString(h[:16])
 	}
 	return ""
+}
+
+const claudeCodeSystemPrefix = "You are Claude Code, Anthropic's official CLI for Claude."
+
+func ensureClaudeCodeSystemPrefix(body map[string]interface{}) {
+	sys, exists := body["system"]
+	if !exists {
+		body["system"] = claudeCodeSystemPrefix
+		return
+	}
+
+	switch s := sys.(type) {
+	case string:
+		if !strings.Contains(s, claudeCodeSystemPrefix) {
+			body["system"] = claudeCodeSystemPrefix + "\n\n" + s
+		}
+	case []interface{}:
+		if len(s) > 0 {
+			if first, ok := s[0].(map[string]interface{}); ok {
+				if text, ok := first["text"].(string); ok && strings.Contains(text, claudeCodeSystemPrefix) {
+					return
+				}
+			}
+		}
+		prefix := map[string]interface{}{"type": "text", "text": claudeCodeSystemPrefix}
+		body["system"] = append([]interface{}{prefix}, s...)
+	}
 }

--- a/internal/server/compat_openai_chat_test.go
+++ b/internal/server/compat_openai_chat_test.go
@@ -57,17 +57,17 @@ func TestCompatOpenAIChatToClaudeRequest(t *testing.T) {
 	if got.Model != "claude-sonnet-4-5" {
 		t.Fatalf("model = %q", got.Model)
 	}
-	if got.System != "system prompt\n\ndeveloper prompt" {
-		t.Fatalf("system = %q", got.System)
+	if got.System != "" {
+		t.Fatalf("system = %q, want empty", got.System)
 	}
 	if got.MaxTokens != maxCompletionTokens {
 		t.Fatalf("max_tokens = %d, want %d", got.MaxTokens, maxCompletionTokens)
 	}
-	if got.Temperature != &temperature {
-		t.Fatalf("temperature pointer was not preserved")
+	if got.Temperature == nil || *got.Temperature != temperature {
+		t.Fatalf("temperature = %#v", got.Temperature)
 	}
-	if got.TopP != &topP {
-		t.Fatalf("top_p pointer was not preserved")
+	if got.TopP == nil || *got.TopP != topP {
+		t.Fatalf("top_p = %#v", got.TopP)
 	}
 	if len(got.StopSequences) != 1 || got.StopSequences[0] != "STOP" {
 		t.Fatalf("stop_sequences = %#v", got.StopSequences)
@@ -75,7 +75,8 @@ func TestCompatOpenAIChatToClaudeRequest(t *testing.T) {
 	if len(got.Messages) != 2 {
 		t.Fatalf("len(messages) = %d, want 2", len(got.Messages))
 	}
-	if got.Messages[0] != (compatClaudeMessage{Role: "user", Content: "hello"}) {
+	wantFirst := compatClaudeSystemReminder([]string{"system prompt", "developer prompt"}) + "\n\nhello"
+	if got.Messages[0] != (compatClaudeMessage{Role: "user", Content: wantFirst}) {
 		t.Fatalf("messages[0] = %#v", got.Messages[0])
 	}
 	if got.Messages[1] != (compatClaudeMessage{Role: "assistant", Content: "hi\n\nthere"}) {
@@ -400,7 +401,7 @@ func TestHandleCompatOpenAIChatCompletions_MinimalLoop(t *testing.T) {
 			if body["model"] != "claude-sonnet-4-5" {
 				t.Fatalf("model = %#v", body["model"])
 			}
-			if body["system"] != "system prompt" {
+			if sys, ok := body["system"].(string); !ok || !strings.Contains(sys, "You are Claude Code, Anthropic's official CLI for Claude.") || strings.Contains(sys, "system prompt") {
 				t.Fatalf("system = %#v", body["system"])
 			}
 
@@ -409,7 +410,8 @@ func TestHandleCompatOpenAIChatCompletions_MinimalLoop(t *testing.T) {
 				t.Fatalf("len(messages) = %d, want 1", len(messages))
 			}
 			msg, _ := messages[0].(map[string]any)
-			if msg["role"] != "user" || msg["content"] != "hello" {
+			wantFirst := compatClaudeSystemReminder([]string{"system prompt"}) + "\n\nhello"
+			if msg["role"] != "user" || msg["content"] != wantFirst {
 				t.Fatalf("message = %#v", msg)
 			}
 

--- a/internal/server/compat_openai_claude.go
+++ b/internal/server/compat_openai_claude.go
@@ -73,9 +73,42 @@ func compatOpenAIChatToClaudeRequest(req *compatOpenAIChatRequest) (*compatClaud
 	if instruction := compatClaudeResponseFormatInstruction(responseFormat); instruction != "" {
 		systemParts = append(systemParts, instruction)
 	}
-	claudeReq.System = strings.Join(systemParts, "\n\n")
+	claudeReq.Messages = compatInjectClaudeSystemReminders(claudeReq.Messages, systemParts)
 
 	return claudeReq, requestedModel, nil
+}
+
+func compatInjectClaudeSystemReminders(messages []compatClaudeMessage, systemParts []string) []compatClaudeMessage {
+	reminder := compatClaudeSystemReminder(systemParts)
+	if reminder == "" {
+		return messages
+	}
+
+	for i := range messages {
+		if messages[i].Role != "user" {
+			continue
+		}
+		if messages[i].Content == "" {
+			messages[i].Content = reminder
+		} else {
+			messages[i].Content = reminder + "\n\n" + messages[i].Content
+		}
+		return messages
+	}
+
+	return append([]compatClaudeMessage{{Role: "user", Content: reminder}}, messages...)
+}
+
+func compatClaudeSystemReminder(systemParts []string) string {
+	blocks := make([]string, 0, len(systemParts))
+	for _, part := range systemParts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		blocks = append(blocks, "<system-reminder>\n"+trimmed+"\n</system-reminder>")
+	}
+	return strings.Join(blocks, "\n\n")
 }
 
 func compatClaudeToOpenAIChatResponse(body []byte, requestedModel string) (*compatOpenAIChatResponse, error) {


### PR DESCRIPTION
## Summary

Split out from #17.

This PR keeps the request-envelope workarounds that are needed for Claude OAuth traffic, without mixing them into the transport/fingerprint PR.

## Changes

- prepend the Claude Code system signature on native Claude requests when it is absent
- translate OpenAI `system` / `developer` messages on the Claude compat surface into an injected `<system-reminder>` block on the first user turn
- preserve `temperature` and `top_p` on the Claude compat surface instead of silently stripping them
- update tests to cover the new native and compat envelope shapes

## Why

Production traces showed that the failing compat requests were rejected because of the translated envelope shape, not because of key/account/model selection:

- Claude OAuth traffic without the expected Claude Code system signature was rejected upstream
- Claude compat requests that translated OpenAI `system` / `developer` into Claude top-level `system` were rejected with upstream `400 invalid_request_error: Error`
- the same instruction content succeeded once it was kept in-message as a `<system-reminder>` on the first user turn

## Verification

- `go test ./internal/server ./internal/identity`
