### PR TITLE
改进 Claude 观测并优化账号列表排序

### DIFF
--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -92,10 +92,11 @@ func (d *ClaudeDriver) Interpret(statusCode int, headers http.Header, body []byt
 
 	case 529:
 		return Effect{
-			Kind:          EffectOverload,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause529),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectOverload,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause529),
+			UpstreamStatus: 529,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 
 	case 429:
@@ -115,59 +116,66 @@ func (d *ClaudeDriver) Interpret(statusCode int, headers http.Header, body []byt
 			}
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: until,
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  until,
+			UpstreamStatus: 429,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 
 	case 403:
 		if banSignalPattern.MatchString(string(body)) {
 			return Effect{
-				Kind:          EffectBlock,
-				Scope:         EffectScopeBucket,
-				CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401),
-				ErrorMessage:  fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
-				UpdatedState:  mustMarshalJSON(state),
+				Kind:           EffectBlock,
+				Scope:          EffectScopeBucket,
+				CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401),
+				ErrorMessage:   fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
+				UpstreamStatus: 403,
+				UpdatedState:   mustMarshalJSON(state),
 			}
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause403),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause403),
+			UpstreamStatus: 403,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 
 	case 400:
 		if banSignalPattern.MatchString(string(body)) {
 			return Effect{
-				Kind:          EffectBlock,
-				Scope:         EffectScopeBucket,
-				CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401),
-				ErrorMessage:  fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
-				UpdatedState:  mustMarshalJSON(state),
+				Kind:           EffectBlock,
+				Scope:          EffectScopeBucket,
+				CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401),
+				ErrorMessage:   fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
+				UpstreamStatus: 400,
+				UpdatedState:   mustMarshalJSON(state),
 			}
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause403),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause403),
+			UpstreamStatus: 400,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 
 	case 401:
 		return Effect{
-			Kind:          EffectAuthFail,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401Refresh),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectAuthFail,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401Refresh),
+			UpstreamStatus: 401,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 
 	case 500:
 		return Effect{
-			Kind:         EffectServerError,
-			Scope:        EffectScopeBucket,
-			UpdatedState: mustMarshalJSON(state),
+			Kind:           EffectServerError,
+			Scope:          EffectScopeBucket,
+			UpstreamStatus: 500,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 	}
 
@@ -301,23 +309,32 @@ func claudeRequiresFreshSession(body map[string]interface{}) bool {
 	if len(messages) > 1 {
 		return true
 	}
-	if len(messages) == 1 {
-		if m, ok := messages[0].(map[string]interface{}); ok {
-			if content, ok := m["content"].([]interface{}); ok {
-				userTexts := 0
-				for _, block := range content {
-					if b, ok := block.(map[string]interface{}); ok && b["type"] == "text" {
-						userTexts++
-					}
-				}
-				if userTexts > 1 {
-					return true
-				}
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "" && role != "user" {
+			return true
+		}
+		content, ok := msg["content"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, block := range content {
+			part, ok := block.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			kind, _ := part["type"].(string)
+			if kind == "tool_use" || kind == "tool_result" {
+				return true
 			}
 		}
 	}
 	tools, _ := body["tools"].([]interface{})
-	return len(tools) == 0
+	return len(tools) > 0
 }
 
 func (d *ClaudeDriver) ParseJSONUsage(body []byte) *Usage {

--- a/internal/driver/claude_test.go
+++ b/internal/driver/claude_test.go
@@ -74,6 +74,9 @@ func TestClaudeInterpret_400DisabledOrganizationBlocks(t *testing.T) {
 	if effect.Scope != EffectScopeBucket {
 		t.Fatalf("Scope = %v, want bucket", effect.Scope)
 	}
+	if effect.UpstreamStatus != http.StatusBadRequest {
+		t.Fatalf("UpstreamStatus = %d, want %d", effect.UpstreamStatus, http.StatusBadRequest)
+	}
 	if effect.CooldownUntil.Before(before.Add(50 * time.Second)) {
 		t.Fatalf("CooldownUntil = %s, want around now+1m", effect.CooldownUntil.Format(time.RFC3339))
 	}
@@ -82,5 +85,96 @@ func TestClaudeInterpret_400DisabledOrganizationBlocks(t *testing.T) {
 	}
 	if !json.Valid(effect.UpdatedState) {
 		t.Fatalf("UpdatedState = %q, want valid JSON", string(effect.UpdatedState))
+	}
+}
+
+func TestClaudeInterpret_403NonBanKeepsRejectStatus(t *testing.T) {
+	d := NewClaudeDriver(ClaudeConfig{
+		Pauses: ErrorPauses{Pause403: 10 * time.Minute},
+	}, nil)
+
+	effect := d.Interpret(http.StatusForbidden, make(http.Header), []byte(`{"error":{"message":"request rejected"}}`), "claude-sonnet-4-6", json.RawMessage(`{}`))
+
+	if effect.Kind != EffectCooldown {
+		t.Fatalf("Kind = %v, want cooldown", effect.Kind)
+	}
+	if effect.UpstreamStatus != http.StatusForbidden {
+		t.Fatalf("UpstreamStatus = %d, want %d", effect.UpstreamStatus, http.StatusForbidden)
+	}
+}
+
+func TestClaudeRequiresFreshSession(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]interface{}
+		want bool
+	}{
+		{
+			name: "one-shot user text stays portable",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{"type": "text", "text": "hello"},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "tools require same session",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": "user", "content": "hello"},
+				},
+				"tools": []interface{}{
+					map[string]interface{}{"name": "run"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "assistant turn requires same session",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": "assistant", "content": "hello"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "tool result requires same session",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{"type": "tool_result", "tool_use_id": "tool-1", "content": "done"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multi-turn requires same session",
+			body: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{"role": "user", "content": "hello"},
+					map[string]interface{}{"role": "user", "content": "follow up"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeRequiresFreshSession(tc.body); got != tc.want {
+				t.Fatalf("claudeRequiresFreshSession() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/driver/codex.go
+++ b/internal/driver/codex.go
@@ -63,9 +63,10 @@ func (d *CodexDriver) Interpret(statusCode int, headers http.Header, body []byte
 
 	case 529:
 		return Effect{
-			Kind:          EffectOverload,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause529),
+			Kind:           EffectOverload,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause529),
+			UpstreamStatus: 529,
 		}
 
 	case 429:
@@ -81,32 +82,36 @@ func (d *CodexDriver) Interpret(statusCode int, headers http.Header, body []byte
 		}
 
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: until,
-			UpdatedState:  state,
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  until,
+			UpstreamStatus: 429,
+			UpdatedState:   state,
 		}
 
 	case 403:
 		if codexBanPattern.MatchString(string(body)) {
 			return Effect{
-				Kind:          EffectBlock,
-				Scope:         EffectScopeBucket,
-				CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401),
-				ErrorMessage:  fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
+				Kind:           EffectBlock,
+				Scope:          EffectScopeBucket,
+				CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401),
+				ErrorMessage:   fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
+				UpstreamStatus: 403,
 			}
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause403),
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause403),
+			UpstreamStatus: 403,
 		}
 
 	case 401:
 		return Effect{
-			Kind:          EffectAuthFail,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401Refresh),
+			Kind:           EffectAuthFail,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401Refresh),
+			UpstreamStatus: 401,
 		}
 	}
 

--- a/internal/driver/gemini.go
+++ b/internal/driver/gemini.go
@@ -80,10 +80,11 @@ func (d *GeminiDriver) Interpret(statusCode int, headers http.Header, body []byt
 		return Effect{Kind: EffectSuccess, Scope: EffectScopeBucket, UpdatedState: mustMarshalJSON(state)}
 	case 529:
 		return Effect{
-			Kind:          EffectOverload,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause529),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectOverload,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause529),
+			UpstreamStatus: 529,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 	case 429:
 		until := time.Now().Add(d.cfg.Pauses.Pause429)
@@ -93,30 +94,34 @@ func (d *GeminiDriver) Interpret(statusCode int, headers http.Header, body []byt
 			until = time.Now().Add(retryAfter)
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			Scope:         EffectScopeBucket,
-			CooldownUntil: until,
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectCooldown,
+			Scope:          EffectScopeBucket,
+			CooldownUntil:  until,
+			UpstreamStatus: 429,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 	case 403:
 		if geminiBanPattern.Match(body) {
 			return Effect{
-				Kind:          EffectBlock,
-				CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401),
-				ErrorMessage:  fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
-				UpdatedState:  mustMarshalJSON(state),
+				Kind:           EffectBlock,
+				CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401),
+				ErrorMessage:   fmt.Sprintf("ban signal detected: %s", truncate(string(body), 200)),
+				UpstreamStatus: 403,
+				UpdatedState:   mustMarshalJSON(state),
 			}
 		}
 		return Effect{
-			Kind:          EffectCooldown,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause403),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectCooldown,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause403),
+			UpstreamStatus: 403,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 	case 401:
 		return Effect{
-			Kind:          EffectAuthFail,
-			CooldownUntil: time.Now().Add(d.cfg.Pauses.Pause401Refresh),
-			UpdatedState:  mustMarshalJSON(state),
+			Kind:           EffectAuthFail,
+			CooldownUntil:  time.Now().Add(d.cfg.Pauses.Pause401Refresh),
+			UpstreamStatus: 401,
+			UpdatedState:   mustMarshalJSON(state),
 		}
 	default:
 		return Effect{Kind: EffectSuccess, Scope: EffectScopeBucket, UpdatedState: mustMarshalJSON(state)}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -39,11 +39,12 @@ const (
 // Effect is the provider-agnostic outcome of an upstream request.
 // Pool.Observe applies it without knowing any provider-specific details.
 type Effect struct {
-	Kind          EffectKind
-	Scope         EffectScope
-	CooldownUntil time.Time
-	ErrorMessage  string
-	UpdatedState  json.RawMessage // opaque provider state blob
+	Kind           EffectKind
+	Scope          EffectScope
+	CooldownUntil  time.Time
+	ErrorMessage   string
+	UpstreamStatus int
+	UpdatedState   json.RawMessage // opaque provider state blob
 }
 
 // RelayInput carries the parsed client request.

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -11,6 +11,7 @@ type EventType string
 
 const (
 	EventBan        EventType = "ban"
+	EventReject     EventType = "reject"
 	EventRefresh    EventType = "refresh"
 	EventRateLimit  EventType = "ratelimit"
 	EventRecover    EventType = "recover"
@@ -21,14 +22,15 @@ const (
 )
 
 type Event struct {
-	Type          EventType  `json:"type"`
-	AccountID     string     `json:"account_id,omitempty"`
-	UserID        string     `json:"user_id,omitempty"`
-	BucketKey     string     `json:"bucket_key,omitempty"`
-	CellID        string     `json:"cell_id,omitempty"`
-	CooldownUntil *time.Time `json:"cooldown_until,omitempty"`
-	Message       string     `json:"message"`
-	Timestamp     time.Time  `json:"ts"`
+	Type           EventType  `json:"type"`
+	AccountID      string     `json:"account_id,omitempty"`
+	UserID         string     `json:"user_id,omitempty"`
+	BucketKey      string     `json:"bucket_key,omitempty"`
+	CellID         string     `json:"cell_id,omitempty"`
+	CooldownUntil  *time.Time `json:"cooldown_until,omitempty"`
+	UpstreamStatus int        `json:"upstream_status,omitempty"`
+	Message        string     `json:"message"`
+	Timestamp      time.Time  `json:"ts"`
 }
 
 type Bus struct {
@@ -75,6 +77,9 @@ func (b *Bus) Publish(e Event) {
 	}
 	if e.CooldownUntil != nil {
 		attrs = append(attrs, "cooldownUntil", e.CooldownUntil.Format(time.RFC3339))
+	}
+	if e.UpstreamStatus > 0 {
+		attrs = append(attrs, "upstreamStatus", e.UpstreamStatus)
 	}
 	if e.Message != "" {
 		attrs = append(attrs, "detail", e.Message)

--- a/internal/pool/pool_observe.go
+++ b/internal/pool/pool_observe.go
@@ -12,6 +12,34 @@ import (
 	"github.com/yansircc/llm-broker/internal/events"
 )
 
+func cooldownEventType(status int) events.EventType {
+	switch status {
+	case 400, 403:
+		return events.EventReject
+	default:
+		return events.EventRateLimit
+	}
+}
+
+func cooldownEventMessage(status int) string {
+	switch status {
+	case 400, 403:
+		return "rejected request"
+	default:
+		return "cooldown"
+	}
+}
+
+func eventMessage(base string, status int, suffix string) string {
+	if base == "" {
+		base = "event"
+	}
+	if status > 0 {
+		return fmt.Sprintf("upstream %d %s%s", status, base, suffix)
+	}
+	return base + suffix
+}
+
 func (p *Pool) RunCleanup(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -211,9 +239,10 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 			p.persistBucketLocked(bucket)
 		}
 		pendingEvent = &events.Event{
-			Type: events.EventRateLimit, AccountID: acct.ID,
-			CooldownUntil: cooldownPtr(result),
-			Message:       "cooldown" + cooldownSuffix(result),
+			Type: cooldownEventType(effect.UpstreamStatus), AccountID: acct.ID,
+			CooldownUntil:  cooldownPtr(result),
+			UpstreamStatus: effect.UpstreamStatus,
+			Message:        eventMessage(cooldownEventMessage(effect.UpstreamStatus), effect.UpstreamStatus, cooldownSuffix(result)),
 		}
 
 	case driver.EffectOverload:
@@ -224,8 +253,9 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		}
 		pendingEvent = &events.Event{
 			Type: events.EventOverload, AccountID: acct.ID,
-			CooldownUntil: cooldownPtr(result),
-			Message:       "overloaded" + cooldownSuffix(result),
+			CooldownUntil:  cooldownPtr(result),
+			UpstreamStatus: effect.UpstreamStatus,
+			Message:        eventMessage("overloaded", effect.UpstreamStatus, cooldownSuffix(result)),
 		}
 
 	case driver.EffectBlock:
@@ -239,8 +269,9 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		markPersist(acct)
 		pendingEvent = &events.Event{
 			Type: events.EventBan, AccountID: acct.ID,
-			CooldownUntil: cooldownPtr(result),
-			Message:       effect.ErrorMessage + cooldownSuffix(result),
+			CooldownUntil:  cooldownPtr(result),
+			UpstreamStatus: effect.UpstreamStatus,
+			Message:        eventMessage(effect.ErrorMessage, effect.UpstreamStatus, cooldownSuffix(result)),
 		}
 
 	case driver.EffectAuthFail:
@@ -251,8 +282,9 @@ func (p *Pool) Observe(accountID string, effect driver.Effect) {
 		}
 		pendingEvent = &events.Event{
 			Type: events.EventRefresh, AccountID: acct.ID,
-			CooldownUntil: cooldownPtr(result),
-			Message:       "auth failed, background refresh triggered",
+			CooldownUntil:  cooldownPtr(result),
+			UpstreamStatus: effect.UpstreamStatus,
+			Message:        eventMessage("auth failed, background refresh triggered", effect.UpstreamStatus, ""),
 		}
 		if p.onAuthFailure != nil {
 			go p.onAuthFailure(acct.ID)

--- a/internal/pool/pool_schedule.go
+++ b/internal/pool/pool_schedule.go
@@ -36,6 +36,11 @@ type bucketCandidate struct {
 	priority int
 }
 
+type SurfaceAvailability struct {
+	Native bool
+	Compat bool
+}
+
 func cellLane(cell *domain.EgressCell) domain.Surface {
 	if cell == nil || len(cell.Labels) == 0 {
 		return ""
@@ -97,6 +102,30 @@ func (p *Pool) IsAvailableForSurface(accountID string, drv driver.SchedulerDrive
 		return false
 	}
 	return p.isAvailable(acct, drv, model, time.Now())
+}
+
+func (p *Pool) SurfaceAvailabilityMap() map[string]SurfaceAvailability {
+	if err := p.refreshState(context.Background()); err != nil {
+		slog.Warn("pool refresh failed", "op", "surface_availability_map", "error", err)
+		return map[string]SurfaceAvailability{}
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	now := time.Now()
+	result := make(map[string]SurfaceAvailability, len(p.accounts))
+	for _, acct := range p.accounts {
+		drv, ok := p.drivers[acct.Provider]
+		if !ok {
+			result[acct.ID] = SurfaceAvailability{}
+			continue
+		}
+		result[acct.ID] = SurfaceAvailability{
+			Native: p.allowedOnSurfaceLocked(acct, domain.SurfaceNative) && p.isAvailable(acct, drv, "", now),
+			Compat: p.allowedOnSurfaceLocked(acct, domain.SurfaceCompat) && p.isAvailable(acct, drv, "", now),
+		}
+	}
+	return result
 }
 
 func (p *Pool) Pick(drv driver.SchedulerDriver, exclusions []Exclusion, model string, boundAccountID string) (*domain.Account, error) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -274,6 +274,43 @@ func TestPickForSurface_SeparatesNativeAndCompatLanes(t *testing.T) {
 	}
 }
 
+func TestSurfaceAvailabilityMap_RespectsSurfaceLanes(t *testing.T) {
+	native := activeAccount("native-avail", "native@x")
+	compat := activeAccount("compat-avail", "compat@x")
+	compat.CellID = "cell-compat"
+
+	p := newTestPool(t, native, compat)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: testDriver,
+	})
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-compat",
+		Name:      "compat",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "10.0.0.3", Port: 11082},
+		Labels:    map[string]string{"lane": "compat"},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-compat): %v", err)
+	}
+
+	availability := p.SurfaceAvailabilityMap()
+
+	if !availability[native.ID].Native {
+		t.Fatal("native legacy-direct account should be native-available")
+	}
+	if availability[native.ID].Compat {
+		t.Fatal("native legacy-direct account should not be compat-available")
+	}
+	if availability[compat.ID].Native {
+		t.Fatal("compat lane account should not be native-available")
+	}
+	if !availability[compat.ID].Compat {
+		t.Fatal("compat lane account should be compat-available")
+	}
+}
+
 func TestCooldownCellForAccount(t *testing.T) {
 	acct := activeAccount("a", "a@x")
 	acct.CellID = "cell-a"
@@ -870,16 +907,18 @@ func TestObserve_EventCooldownUsesActualValue(t *testing.T) {
 
 	longCooldown := time.Now().Add(30 * time.Minute)
 	p.Observe(acct.ID, driver.Effect{
-		Kind:          driver.EffectCooldown,
-		Scope:         driver.EffectScopeBucket,
-		CooldownUntil: longCooldown,
+		Kind:           driver.EffectCooldown,
+		Scope:          driver.EffectScopeBucket,
+		CooldownUntil:  longCooldown,
+		UpstreamStatus: 429,
 	})
 
 	shortCooldown := time.Now().Add(5 * time.Minute)
 	p.Observe(acct.ID, driver.Effect{
-		Kind:          driver.EffectCooldown,
-		Scope:         driver.EffectScopeBucket,
-		CooldownUntil: shortCooldown,
+		Kind:           driver.EffectCooldown,
+		Scope:          driver.EffectScopeBucket,
+		CooldownUntil:  shortCooldown,
+		UpstreamStatus: 429,
 	})
 
 	recent := p.bus.Recent(1)
@@ -890,6 +929,9 @@ func TestObserve_EventCooldownUsesActualValue(t *testing.T) {
 	if evt.Type != events.EventRateLimit {
 		t.Fatalf("expected EventRateLimit, got %s", evt.Type)
 	}
+	if evt.UpstreamStatus != 429 {
+		t.Fatalf("event UpstreamStatus = %d, want 429", evt.UpstreamStatus)
+	}
 	if evt.CooldownUntil == nil {
 		t.Fatal("event CooldownUntil is nil")
 	}
@@ -898,6 +940,40 @@ func TestObserve_EventCooldownUsesActualValue(t *testing.T) {
 	}
 	if !strings.Contains(evt.Message, longCooldown.UTC().Format(time.RFC3339)) {
 		t.Fatalf("event Message should contain actual cooldown time, got %q", evt.Message)
+	}
+	if !strings.Contains(evt.Message, "upstream 429") {
+		t.Fatalf("event Message should contain upstream status, got %q", evt.Message)
+	}
+}
+
+func TestObserve_Cooldown403EmitsRejectEvent(t *testing.T) {
+	acct := activeAccount("rej-1", "rej@test.com")
+	p := newTestPool(t, acct)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: testDriver,
+	})
+
+	until := time.Now().Add(10 * time.Minute)
+	p.Observe(acct.ID, driver.Effect{
+		Kind:           driver.EffectCooldown,
+		Scope:          driver.EffectScopeBucket,
+		CooldownUntil:  until,
+		UpstreamStatus: 403,
+	})
+
+	recent := p.bus.Recent(1)
+	if len(recent) != 1 {
+		t.Fatalf("len(recent) = %d, want 1", len(recent))
+	}
+	evt := recent[0]
+	if evt.Type != events.EventReject {
+		t.Fatalf("expected EventReject, got %s", evt.Type)
+	}
+	if evt.UpstreamStatus != 403 {
+		t.Fatalf("event UpstreamStatus = %d, want 403", evt.UpstreamStatus)
+	}
+	if !strings.Contains(evt.Message, "upstream 403") {
+		t.Fatalf("event Message = %q, want upstream 403", evt.Message)
 	}
 }
 

--- a/internal/server/admin_accounts.go
+++ b/internal/server/admin_accounts.go
@@ -14,22 +14,26 @@ import (
 func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 	accounts := s.pool.List()
 	cellCounts := accountCountsByCell(accounts)
+	availability := s.pool.SurfaceAvailabilityMap()
 
 	views := make([]AccountListItem, 0, len(accounts))
 	for _, a := range accounts {
 		proj := s.projectAccount(a)
+		avail := availability[a.ID]
 		views = append(views, AccountListItem{
-			ID:            a.ID,
-			Email:         a.Email,
-			Provider:      string(a.Provider),
-			Status:        string(a.Status),
-			Weight:        proj.effectiveWeight,
-			WeightMode:    a.PriorityMode,
-			LastUsedAt:    a.LastUsedAt,
-			CooldownUntil: a.CooldownUntil,
-			CellID:        a.CellID,
-			Cell:          toCellSummary(a.Cell, cellCounts[a.CellID]),
-			Windows:       proj.windows,
+			ID:              a.ID,
+			Email:           a.Email,
+			Provider:        string(a.Provider),
+			Status:          string(a.Status),
+			Weight:          proj.effectiveWeight,
+			WeightMode:      a.PriorityMode,
+			LastUsedAt:      a.LastUsedAt,
+			CooldownUntil:   a.CooldownUntil,
+			CellID:          a.CellID,
+			AvailableNative: avail.Native,
+			AvailableCompat: avail.Compat,
+			Cell:            toCellSummary(a.Cell, cellCounts[a.CellID]),
+			Windows:         proj.windows,
 		})
 	}
 	writeJSON(w, http.StatusOK, views)

--- a/internal/server/admin_dashboard.go
+++ b/internal/server/admin_dashboard.go
@@ -34,20 +34,24 @@ func (s *Server) dashboardUsage(ctx context.Context, loc *time.Location) []domai
 
 func (s *Server) dashboardAccounts() []DashboardAccount {
 	accounts := s.pool.List()
+	availability := s.pool.SurfaceAvailabilityMap()
 	views := make([]DashboardAccount, 0, len(accounts))
 	for _, acct := range accounts {
 		proj := s.projectAccount(acct)
+		avail := availability[acct.ID]
 		views = append(views, DashboardAccount{
-			ID:            acct.ID,
-			Email:         acct.Email,
-			Provider:      string(acct.Provider),
-			Status:        string(acct.Status),
-			WeightMode:    acct.PriorityMode,
-			Weight:        proj.effectiveWeight,
-			CooldownUntil: acct.CooldownUntil,
-			LastUsedAt:    acct.LastUsedAt,
-			CellID:        acct.CellID,
-			Windows:       proj.windows,
+			ID:              acct.ID,
+			Email:           acct.Email,
+			Provider:        string(acct.Provider),
+			Status:          string(acct.Status),
+			WeightMode:      acct.PriorityMode,
+			Weight:          proj.effectiveWeight,
+			CooldownUntil:   acct.CooldownUntil,
+			LastUsedAt:      acct.LastUsedAt,
+			CellID:          acct.CellID,
+			AvailableNative: avail.Native,
+			AvailableCompat: avail.Compat,
+			Windows:         proj.windows,
 		})
 	}
 	return views
@@ -85,14 +89,15 @@ func (s *Server) dashboardEvents(limit int) []DashboardEvent {
 	for i := len(recentEvents) - 1; i >= 0; i-- {
 		event := recentEvents[i]
 		views = append(views, DashboardEvent{
-			Type:          string(event.Type),
-			AccountID:     event.AccountID,
-			UserID:        event.UserID,
-			BucketKey:     event.BucketKey,
-			CellID:        event.CellID,
-			CooldownUntil: event.CooldownUntil,
-			Message:       event.Message,
-			Timestamp:     event.Timestamp.Format(time.RFC3339),
+			Type:           string(event.Type),
+			AccountID:      event.AccountID,
+			UserID:         event.UserID,
+			BucketKey:      event.BucketKey,
+			CellID:         event.CellID,
+			CooldownUntil:  event.CooldownUntil,
+			UpstreamStatus: event.UpstreamStatus,
+			Message:        event.Message,
+			Timestamp:      event.Timestamp.Format(time.RFC3339),
 		})
 	}
 	return views

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -218,6 +218,38 @@ func TestDashboard_UsersIncludePolicy(t *testing.T) {
 	}
 }
 
+func TestDashboard_EventsIncludeUpstreamStatus(t *testing.T) {
+	srv := newTestServer(t)
+	until := time.Now().Add(10 * time.Minute).UTC()
+	srv.bus.Publish(events.Event{
+		Type:           events.EventReject,
+		AccountID:      "acct-1",
+		CooldownUntil:  &until,
+		UpstreamStatus: http.StatusForbidden,
+		Message:        "upstream 403 rejected request",
+	})
+
+	w := httptest.NewRecorder()
+	srv.handleDashboard(w, adminRequest("GET", "/admin/dashboard"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(result.Events))
+	}
+	if got := result.Events[0]["upstream_status"]; got != float64(http.StatusForbidden) {
+		t.Fatalf("upstream_status = %#v, want %d", got, http.StatusForbidden)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Account detail contract tests
 // ---------------------------------------------------------------------------
@@ -248,6 +280,77 @@ func TestGetAccount_EmptySessions(t *testing.T) {
 
 	// sessions must be [] not null
 	assertJSONArray(t, body, "sessions")
+}
+
+func TestListAccounts_IncludesSurfaceAvailability(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-native",
+		Email:    "native@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-compat",
+		Email:    "compat@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+		CellID:   "cell-compat-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-compat-1",
+		Name:      "compat lane",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11082},
+		Labels:    map[string]string{"lane": "compat"},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+	srv.pool.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderClaude: driver.NewClaudeDriver(driver.ClaudeConfig{}, nil),
+	})
+
+	w := httptest.NewRecorder()
+	srv.handleListAccounts(w, adminRequest("GET", "/admin/accounts"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("len(accounts) = %d, want 2", len(result))
+	}
+
+	byID := make(map[string]map[string]any, len(result))
+	for _, item := range result {
+		id, _ := item["id"].(string)
+		byID[id] = item
+	}
+
+	if got := byID["acct-native"]["available_native"]; got != true {
+		t.Fatalf("acct-native available_native = %#v, want true", got)
+	}
+	if got := byID["acct-native"]["available_compat"]; got != false {
+		t.Fatalf("acct-native available_compat = %#v, want false", got)
+	}
+	if got := byID["acct-compat"]["available_native"]; got != false {
+		t.Fatalf("acct-compat available_native = %#v, want false", got)
+	}
+	if got := byID["acct-compat"]["available_compat"]; got != true {
+		t.Fatalf("acct-compat available_compat = %#v, want true", got)
+	}
 }
 
 func TestGetAccount_NullableFields(t *testing.T) {

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -45,16 +45,18 @@ type EgressCellSummaryResponse struct {
 }
 
 type DashboardAccount struct {
-	ID            string                      `json:"id"`
-	Email         string                      `json:"email"`
-	Provider      string                      `json:"provider"`
-	Status        string                      `json:"status"`
-	WeightMode    string                      `json:"weight_mode"`
-	Weight        int                         `json:"weight"`
-	CooldownUntil *time.Time                  `json:"cooldown_until,omitempty"`
-	LastUsedAt    *time.Time                  `json:"last_used_at,omitempty"`
-	CellID        string                      `json:"cell_id,omitempty"`
-	Windows       []UtilizationWindowResponse `json:"windows"`
+	ID              string                      `json:"id"`
+	Email           string                      `json:"email"`
+	Provider        string                      `json:"provider"`
+	Status          string                      `json:"status"`
+	WeightMode      string                      `json:"weight_mode"`
+	Weight          int                         `json:"weight"`
+	CooldownUntil   *time.Time                  `json:"cooldown_until,omitempty"`
+	LastUsedAt      *time.Time                  `json:"last_used_at,omitempty"`
+	CellID          string                      `json:"cell_id,omitempty"`
+	AvailableNative bool                        `json:"available_native"`
+	AvailableCompat bool                        `json:"available_compat"`
+	Windows         []UtilizationWindowResponse `json:"windows"`
 }
 
 type DashboardUser struct {
@@ -69,14 +71,15 @@ type DashboardUser struct {
 }
 
 type DashboardEvent struct {
-	Type          string     `json:"type"`
-	AccountID     string     `json:"account_id,omitempty"`
-	UserID        string     `json:"user_id,omitempty"`
-	BucketKey     string     `json:"bucket_key,omitempty"`
-	CellID        string     `json:"cell_id,omitempty"`
-	CooldownUntil *time.Time `json:"cooldown_until,omitempty"`
-	Message       string     `json:"message"`
-	Timestamp     string     `json:"ts"`
+	Type           string     `json:"type"`
+	AccountID      string     `json:"account_id,omitempty"`
+	UserID         string     `json:"user_id,omitempty"`
+	BucketKey      string     `json:"bucket_key,omitempty"`
+	CellID         string     `json:"cell_id,omitempty"`
+	CooldownUntil  *time.Time `json:"cooldown_until,omitempty"`
+	UpstreamStatus int        `json:"upstream_status,omitempty"`
+	Message        string     `json:"message"`
+	Timestamp      string     `json:"ts"`
 }
 
 type ProviderOptionResponse struct {
@@ -119,17 +122,19 @@ type AccountDetailResponse struct {
 // ---------------------------------------------------------------------------
 
 type AccountListItem struct {
-	ID            string                      `json:"id"`
-	Email         string                      `json:"email"`
-	Provider      string                      `json:"provider"`
-	Status        string                      `json:"status"`
-	Weight        int                         `json:"weight"`
-	WeightMode    string                      `json:"weight_mode"`
-	LastUsedAt    *time.Time                  `json:"last_used_at,omitempty"`
-	CooldownUntil *time.Time                  `json:"cooldown_until,omitempty"`
-	CellID        string                      `json:"cell_id,omitempty"`
-	Cell          *EgressCellSummaryResponse  `json:"cell,omitempty"`
-	Windows       []UtilizationWindowResponse `json:"windows"`
+	ID              string                      `json:"id"`
+	Email           string                      `json:"email"`
+	Provider        string                      `json:"provider"`
+	Status          string                      `json:"status"`
+	Weight          int                         `json:"weight"`
+	WeightMode      string                      `json:"weight_mode"`
+	LastUsedAt      *time.Time                  `json:"last_used_at,omitempty"`
+	CooldownUntil   *time.Time                  `json:"cooldown_until,omitempty"`
+	CellID          string                      `json:"cell_id,omitempty"`
+	AvailableNative bool                        `json:"available_native"`
+	AvailableCompat bool                        `json:"available_compat"`
+	Cell            *EgressCellSummaryResponse  `json:"cell,omitempty"`
+	Windows         []UtilizationWindowResponse `json:"windows"`
 }
 
 type EgressCellResponse struct {

--- a/web/src/lib/admin-types.ts
+++ b/web/src/lib/admin-types.ts
@@ -39,6 +39,7 @@ export interface DashboardEvent {
 	bucket_key?: string;
 	cell_id?: string;
 	cooldown_until?: string;
+	upstream_status?: number;
 	message: string;
 	ts: string;
 }
@@ -62,6 +63,8 @@ export interface AccountListItem {
 	last_used_at: string | null;
 	cooldown_until: string | null;
 	cell_id?: string;
+	available_native: boolean;
+	available_compat: boolean;
 	cell?: EgressCellSummary | null;
 	windows: UtilWindow[];
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -84,7 +84,7 @@ export function remainTime(resetTs: number | null): string {
 
 export function eventTypeColor(type: string): string {
 	const t = type.toUpperCase();
-	if (t === 'BAN' || t === '403' || t === '401') return 'r';
+	if (t === 'BAN' || t === 'REJECT' || t === '403' || t === '401') return 'r';
 	if (t === '429' || t === 'RATELIMIT' || t === '5H_STOP' || t === '5H-STOP') return 'o';
 	if (t === 'REFRESH' || t === 'RECOVER') return 'g';
 	if (t === 'OVERLOAD' || t === 'RELAY_ERROR') return 'o';

--- a/web/src/routes/accounts/+page.svelte
+++ b/web/src/routes/accounts/+page.svelte
@@ -13,11 +13,20 @@
 		window_labels: string[];
 	}
 
+	type SortKey = 'email' | 'status' | 'cell' | 'weight' | 'cooldown' | 'last_used' | `window:${number}`;
+	type SortDirection = 'asc' | 'desc';
+
+	interface SortState {
+		key: SortKey;
+		dir: SortDirection;
+	}
+
 	let accounts = $state<AccountListItem[]>([]);
 	let providers = $state<ProviderOption[]>([]);
 	let error = $state('');
 	let providerError = $state('');
 	let lastRefresh = $state('');
+	let groupSorts = $state<Record<string, SortState>>({});
 
 	$effect(() => {
 		loadAll();
@@ -44,6 +53,150 @@
 
 	function windowAt(account: AccountListItem, index: number) {
 		return account.windows[index] ?? null;
+	}
+
+	function defaultSortState(): SortState {
+		return { key: 'email', dir: 'asc' };
+	}
+
+	function defaultDirection(key: SortKey): SortDirection {
+		switch (key) {
+			case 'weight':
+			case 'cooldown':
+			case 'last_used':
+				return 'desc';
+			default:
+				return 'asc';
+		}
+	}
+
+	function sortStateFor(provider: string): SortState {
+		return groupSorts[provider] ?? defaultSortState();
+	}
+
+	function setSort(provider: string, key: SortKey) {
+		const current = sortStateFor(provider);
+		groupSorts[provider] = current.key === key
+			? { key, dir: current.dir === 'asc' ? 'desc' : 'asc' }
+			: { key, dir: defaultDirection(key) };
+	}
+
+	function isSortActive(provider: string, key: SortKey): boolean {
+		return sortStateFor(provider).key === key;
+	}
+
+	function sortIndicator(provider: string, key: SortKey): string {
+		if (!isSortActive(provider, key)) return '';
+		return sortStateFor(provider).dir === 'asc' ? '↑' : '↓';
+	}
+
+	function ariaSort(provider: string, key: SortKey): 'ascending' | 'descending' | 'none' {
+		if (!isSortActive(provider, key)) return 'none';
+		return sortStateFor(provider).dir === 'asc' ? 'ascending' : 'descending';
+	}
+
+	function windowSortKey(index: number): SortKey {
+		return `window:${index}`;
+	}
+
+	function parseWindowSortIndex(key: SortKey): number | null {
+		if (!key.startsWith('window:')) return null;
+		const index = Number.parseInt(key.slice('window:'.length), 10);
+		return Number.isFinite(index) ? index : null;
+	}
+
+	function timestamp(value: string | null | undefined): number | null {
+		if (!value) return null;
+		const result = new Date(value).getTime();
+		return Number.isNaN(result) ? null : result;
+	}
+
+	function cellLabel(account: AccountListItem): string {
+		return account.cell?.name ?? account.cell_id ?? 'legacy direct';
+	}
+
+	function statusRank(status: string): number {
+		switch (status) {
+			case 'active':
+				return 0;
+			case 'blocked':
+				return 1;
+			case 'error':
+				return 2;
+			case 'disabled':
+				return 9;
+			default:
+				return 5;
+		}
+	}
+
+	function windowRemain(account: AccountListItem, index: number): number | null {
+		if (account.status === 'blocked' || account.status === 'disabled') {
+			return null;
+		}
+		const window = windowAt(account, index);
+		if (!window) return null;
+		return 100 - window.pct;
+	}
+
+	function compareNumbers(left: number, right: number, dir: SortDirection): number {
+		if (left === right) return 0;
+		const diff = left - right;
+		return dir === 'asc' ? diff : -diff;
+	}
+
+	function compareNullableNumbers(left: number | null, right: number | null, dir: SortDirection): number {
+		if (left == null && right == null) return 0;
+		if (left == null) return 1;
+		if (right == null) return -1;
+		return compareNumbers(left, right, dir);
+	}
+
+	function compareStrings(left: string, right: string, dir: SortDirection): number {
+		const diff = left.localeCompare(right);
+		return dir === 'asc' ? diff : -diff;
+	}
+
+	function compareDisabledLast(left: AccountListItem, right: AccountListItem): number {
+		const leftDisabled = left.status === 'disabled';
+		const rightDisabled = right.status === 'disabled';
+		if (leftDisabled === rightDisabled) return 0;
+		return leftDisabled ? 1 : -1;
+	}
+
+	function compareAccounts(left: AccountListItem, right: AccountListItem, sort: SortState): number {
+		switch (sort.key) {
+			case 'email':
+				return compareStrings(left.email, right.email, sort.dir);
+			case 'status':
+				return compareNumbers(statusRank(left.status), statusRank(right.status), sort.dir);
+			case 'cell':
+				return compareStrings(cellLabel(left), cellLabel(right), sort.dir);
+			case 'weight':
+				return compareNumbers(left.weight, right.weight, sort.dir);
+			case 'cooldown':
+				return compareNullableNumbers(timestamp(left.cooldown_until), timestamp(right.cooldown_until), sort.dir);
+			case 'last_used':
+				return compareNullableNumbers(timestamp(left.last_used_at), timestamp(right.last_used_at), sort.dir);
+			default: {
+				const index = parseWindowSortIndex(sort.key);
+				if (index == null) return 0;
+				return compareNullableNumbers(windowRemain(left, index), windowRemain(right, index), sort.dir);
+			}
+		}
+	}
+
+	function sortAccounts(provider: string, items: AccountListItem[]): AccountListItem[] {
+		const sort = sortStateFor(provider);
+		return [...items].sort((left, right) => {
+			const disabled = compareDisabledLast(left, right);
+			if (disabled !== 0) return disabled;
+
+			const primary = compareAccounts(left, right, sort);
+			if (primary !== 0) return primary;
+
+			return left.email.localeCompare(right.email);
+		});
 	}
 
 	function groupAccounts(items: AccountListItem[]): AccountGroup[] {
@@ -75,6 +228,7 @@
 			const existing = grouped.get(provider.id);
 			if (existing) {
 				existing.label = provider.label;
+				existing.accounts = sortAccounts(existing.provider, existing.accounts);
 				ordered.push(existing);
 				grouped.delete(provider.id);
 				continue;
@@ -88,9 +242,18 @@
 		}
 
 		for (const leftover of [...grouped.values()].sort((a, b) => a.provider.localeCompare(b.provider))) {
+			leftover.accounts = sortAccounts(leftover.provider, leftover.accounts);
 			ordered.push(leftover);
 		}
 		return ordered;
+	}
+
+	function activeCount(items: AccountListItem[]): number {
+		return items.filter((account) => account.status === 'active').length;
+	}
+
+	function availableCount(items: AccountListItem[], surface: 'native' | 'compat'): number {
+		return items.filter((account) => surface === 'native' ? account.available_native : account.available_compat).length;
 	}
 </script>
 
@@ -106,20 +269,54 @@
 	{:else}
 		{#each accountGroups as group (group.provider)}
 			<h2>{group.provider} accounts <a href={addAccountPath(base, group.provider)} class="add-link">[+ add]</a></h2>
+			<div class="sub">
+				{group.accounts.length} total
+				&middot; active {activeCount(group.accounts)}
+				&middot; available(native) {availableCount(group.accounts, 'native')}
+				&middot; available(compat) {availableCount(group.accounts, 'compat')}
+			</div>
 			{#if group.accounts.length === 0}
 				<p class="muted">no {group.label} accounts</p>
 			{:else}
 				<table>
 					<thead>
 						<tr>
-							<th>email</th>
-							<th>status</th>
-							<th>cell</th>
-							<th>weight</th>
-							<th>cooldown</th>
-							<th>last used</th>
+							<th aria-sort={ariaSort(group.provider, 'email')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'email') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'email')}>
+									email <span class="sort-indicator">{sortIndicator(group.provider, 'email')}</span>
+								</button>
+							</th>
+							<th aria-sort={ariaSort(group.provider, 'status')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'status') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'status')}>
+									status <span class="sort-indicator">{sortIndicator(group.provider, 'status')}</span>
+								</button>
+							</th>
+							<th aria-sort={ariaSort(group.provider, 'cell')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'cell') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'cell')}>
+									cell <span class="sort-indicator">{sortIndicator(group.provider, 'cell')}</span>
+								</button>
+							</th>
+							<th aria-sort={ariaSort(group.provider, 'weight')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'weight') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'weight')}>
+									weight <span class="sort-indicator">{sortIndicator(group.provider, 'weight')}</span>
+								</button>
+							</th>
+							<th aria-sort={ariaSort(group.provider, 'cooldown')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'cooldown') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'cooldown')}>
+									cooldown <span class="sort-indicator">{sortIndicator(group.provider, 'cooldown')}</span>
+								</button>
+							</th>
+							<th aria-sort={ariaSort(group.provider, 'last_used')}>
+								<button type="button" class="link sort-link {isSortActive(group.provider, 'last_used') ? 'sort-active' : ''}" onclick={() => setSort(group.provider, 'last_used')}>
+									last used <span class="sort-indicator">{sortIndicator(group.provider, 'last_used')}</span>
+								</button>
+							</th>
 							{#each group.window_labels as label, index (`${group.provider}:${label}:${index}`)}
-								<th class="num">{label}</th>
+								<th class="num" aria-sort={ariaSort(group.provider, windowSortKey(index))}>
+									<button type="button" class="link sort-link sort-link-num {isSortActive(group.provider, windowSortKey(index)) ? 'sort-active' : ''}" onclick={() => setSort(group.provider, windowSortKey(index))}>
+										{label} <span class="sort-indicator">{sortIndicator(group.provider, windowSortKey(index))}</span>
+									</button>
+								</th>
 							{/each}
 						</tr>
 					</thead>
@@ -163,3 +360,33 @@
 		<p class="error-msg">{providerError}</p>
 	{/if}
 {/if}
+
+<style>
+	.sort-link {
+		color: inherit;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-weight: inherit;
+	}
+
+	.sort-link:hover {
+		text-decoration: underline;
+	}
+
+	.sort-link-num {
+		justify-content: flex-end;
+		width: 100%;
+	}
+
+	.sort-active {
+		font-weight: bold;
+	}
+
+	.sort-indicator {
+		display: inline-block;
+		min-width: 1ch;
+		color: #888;
+	}
+</style>

--- a/web/src/routes/activity/+page.svelte
+++ b/web/src/routes/activity/+page.svelte
@@ -41,6 +41,7 @@
 		if (ev.account_id) facts.push({ label: 'account', value: ev.account_id });
 		if (ev.bucket_key) facts.push({ label: 'bucket', value: ev.bucket_key });
 		if (ev.cell_id) facts.push({ label: 'cell', value: ev.cell_id });
+		if (ev.upstream_status) facts.push({ label: 'status', value: String(ev.upstream_status) });
 		if (ev.cooldown_until) facts.push({ label: 'cooldown', value: fmtDate(ev.cooldown_until) });
 		return facts;
 	}

--- a/web/src/routes/dashboard/+page.svelte
+++ b/web/src/routes/dashboard/+page.svelte
@@ -60,6 +60,18 @@
 			default: return 'tag';
 		}
 	}
+
+	function activeAccounts() {
+		return data?.accounts.filter((acct) => acct.status === 'active').length ?? 0;
+	}
+
+	function availableNativeAccounts() {
+		return data?.accounts.filter((acct) => acct.available_native).length ?? 0;
+	}
+
+	function availableCompatAccounts() {
+		return data?.accounts.filter((acct) => acct.available_compat).length ?? 0;
+	}
 </script>
 
 {#if error}
@@ -73,6 +85,9 @@
 	<div class="bar">
 		<span>cells {cells.length}</span>
 		<span>accounts {data.accounts.length}</span>
+		<span>active {activeAccounts()}</span>
+		<span>available native {availableNativeAccounts()}</span>
+		<span>available compat {availableCompatAccounts()}</span>
 		<span>legacy direct {data.accounts.filter((acct) => !acct.cell_id).length}</span>
 		<span>cooling cells {cells.filter((cell) => activeCooldownUntil(cell)).length}</span>
 		<span><a href="{base}/migrations">migration</a></span>


### PR DESCRIPTION
## 背景
- 当前 Claude 的 400/403 与 429 在事件面板里都会被看成限流，运维容易误判。
- `claudeRequiresFreshSession()` 过于激进，导致普通 one-shot 请求也会被强制绑在同一账号上。
- 管理页只展示 active 数，不能反映 native / compat 两个 surface 的真实可调度数量。
- 账号列表缺少组内排序能力，`disabled` 账号混在中间不利于排查。

## 改动
- 区分 Claude 的 `429` 与 `400/403` 事件：
  - `429` 继续记为 `ratelimit`
  - `400/403` 记为 `reject`
  - 事件补充 `upstream_status`，message 直接带上 upstream status
- 放宽 `claudeRequiresFreshSession()`：只有多轮、assistant 参与、tools / tool_result 场景才要求同账号继续；单条 one-shot 文本请求不再强制 stickiness。
- 后端补充按 surface 计算的 `available_native` / `available_compat`，并在 dashboard / accounts 页面展示。
- accounts 页面支持点击表头排序；每个 provider 分组独立维护排序状态，并且 `disabled` 账号始终固定排在该组最底部。

## 验证
- `go test ./internal/driver ./internal/pool ./internal/server`
- `npm run build`