### PR TITLE
feat: harden compat observability and request validation

### DIFF
--- a/internal/driver/claude.go
+++ b/internal/driver/claude.go
@@ -249,7 +249,10 @@ func (d *ClaudeDriver) StreamResponse(ctx context.Context, w http.ResponseWriter
 			break
 		}
 		line := scanner.Text()
-		fmt.Fprintf(w, "%s\n", line)
+		if _, err := fmt.Fprintf(w, "%s\n", line); err != nil {
+			completed = false
+			break
+		}
 		if line == "" {
 			flusher.Flush()
 		}
@@ -261,6 +264,9 @@ func (d *ClaudeDriver) StreamResponse(ctx context.Context, w http.ResponseWriter
 				capturedUsage = u
 			}
 		}
+	}
+	if scanner.Err() != nil {
+		completed = false
 	}
 	flusher.Flush()
 	return completed, capturedUsage
@@ -296,9 +302,13 @@ func (d *ClaudeDriver) ParseNonRetriable(statusCode int, body []byte) bool {
 }
 
 func (d *ClaudeDriver) WriteError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	fmt.Fprintf(w, `{"type":"error","error":{"type":"api_error","message":"%s"}}`, msg)
+	writeDriverJSON(w, status, map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    "api_error",
+			"message": msg,
+		},
+	})
 }
 
 func (d *ClaudeDriver) WriteUpstreamError(w http.ResponseWriter, statusCode int, body []byte, isStream bool) {

--- a/internal/driver/claude_build_request_test.go
+++ b/internal/driver/claude_build_request_test.go
@@ -177,6 +177,26 @@ func TestClaudeBuildRequestRejectsUnsupportedModelsLocally(t *testing.T) {
 			t.Fatalf("Message = %q", requestErr.Message)
 		}
 	})
+
+	t.Run("compat-only alias remains rejected on native path", func(t *testing.T) {
+		body := buildClaudeRequestBody(t, "claude-sonnet-4-5-20250929", map[string]interface{}{
+			"max_tokens": 1,
+			"messages": []interface{}{
+				map[string]interface{}{"role": "user", "content": "hello"},
+			},
+		})
+		_, err := buildClaudeUpstreamBodyE(t, body, false)
+		var requestErr *RequestValidationError
+		if !errors.As(err, &requestErr) {
+			t.Fatalf("error = %v, want RequestValidationError", err)
+		}
+		if requestErr.StatusCode != http.StatusBadRequest {
+			t.Fatalf("StatusCode = %d, want 400", requestErr.StatusCode)
+		}
+		if !strings.Contains(requestErr.Message, "unsupported Claude model") {
+			t.Fatalf("Message = %q", requestErr.Message)
+		}
+	})
 }
 
 func buildClaudeRequestBody(t *testing.T, model string, body map[string]interface{}) []byte {

--- a/internal/driver/codex.go
+++ b/internal/driver/codex.go
@@ -195,9 +195,13 @@ func (d *CodexDriver) ParseNonRetriable(statusCode int, body []byte) bool {
 }
 
 func (d *CodexDriver) WriteError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	fmt.Fprintf(w, `{"error":{"message":"%s","type":"error","code":%d}}`, msg, status)
+	writeDriverJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"message": msg,
+			"type":    "error",
+			"code":    status,
+		},
+	})
 }
 
 func (d *CodexDriver) WriteUpstreamError(w http.ResponseWriter, statusCode int, body []byte, _ bool) {

--- a/internal/driver/gemini.go
+++ b/internal/driver/gemini.go
@@ -214,9 +214,12 @@ func (d *GeminiDriver) RetrySameAccount(_ int, _ []byte, _ int) bool { return fa
 func (d *GeminiDriver) ParseNonRetriable(_ int, _ []byte) bool { return false }
 
 func (d *GeminiDriver) WriteError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	fmt.Fprintf(w, `{"error":{"message":"%s","code":%d}}`, msg, status)
+	writeDriverJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"message": msg,
+			"code":    status,
+		},
+	})
 }
 
 func (d *GeminiDriver) WriteUpstreamError(w http.ResponseWriter, statusCode int, body []byte, _ bool) {

--- a/internal/driver/http_json.go
+++ b/internal/driver/http_json.go
@@ -1,0 +1,15 @@
+package driver
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+func writeDriverJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Error("driver write json failed", "status", status, "error", err)
+	}
+}

--- a/internal/driver/write_error_test.go
+++ b/internal/driver/write_error_test.go
@@ -1,0 +1,81 @@
+package driver
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDriverWriteErrorEscapesJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(*httptest.ResponseRecorder, int, string)
+		check func(*testing.T, map[string]any)
+	}{
+		{
+			name: "claude",
+			write: func(w *httptest.ResponseRecorder, status int, msg string) {
+				(&ClaudeDriver{}).WriteError(w, status, msg)
+			},
+			check: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				errBody, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error body = %#v", body["error"])
+				}
+				if errBody["message"] != `unsupported Claude model "claude-sonnet-4-20250514"` {
+					t.Fatalf("message = %#v", errBody["message"])
+				}
+			},
+		},
+		{
+			name: "codex",
+			write: func(w *httptest.ResponseRecorder, status int, msg string) {
+				(&CodexDriver{}).WriteError(w, status, msg)
+			},
+			check: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				errBody, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error body = %#v", body["error"])
+				}
+				if errBody["message"] != `unsupported model "gpt-5.4"` {
+					t.Fatalf("message = %#v", errBody["message"])
+				}
+			},
+		},
+		{
+			name: "gemini",
+			write: func(w *httptest.ResponseRecorder, status int, msg string) {
+				(&GeminiDriver{}).WriteError(w, status, msg)
+			},
+			check: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				errBody, ok := body["error"].(map[string]any)
+				if !ok {
+					t.Fatalf("error body = %#v", body["error"])
+				}
+				if errBody["message"] != `unsupported model "gemini-foo"` {
+					t.Fatalf("message = %#v", errBody["message"])
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			tc.write(recorder, 400, map[string]string{
+				"claude": `unsupported Claude model "claude-sonnet-4-20250514"`,
+				"codex":  `unsupported model "gpt-5.4"`,
+				"gemini": `unsupported model "gemini-foo"`,
+			}[tc.name])
+
+			var body map[string]any
+			if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v, body = %q", err, recorder.Body.String())
+			}
+			tc.check(t, body)
+		})
+	}
+}

--- a/internal/relay/relay_attempt.go
+++ b/internal/relay/relay_attempt.go
@@ -54,6 +54,19 @@ func relayEffectKind(kind driver.EffectKind) string {
 	}
 }
 
+func requestValidationEffectKind(statusCode int) string {
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		return "overload"
+	case statusCode == http.StatusUnauthorized:
+		return "auth_fail"
+	case statusCode >= 500:
+		return "server_error"
+	default:
+		return "reject"
+	}
+}
+
 func upstreamRequestID(headers http.Header) string {
 	if headers == nil {
 		return ""
@@ -179,10 +192,24 @@ func (r *Relay) executeRelayAttempt(
 		return relayAttemptContinue
 	}
 
+	attemptStartedAt := time.Now()
 	upReq, err := drv.BuildRequest(ctx, prepared.input, acct, accessToken)
 	if err != nil {
 		var requestErr *driver.RequestValidationError
 		if errors.As(err, &requestErr) {
+			entry := r.baseRequestLog(prepared, acct, attempt)
+			entry.Status = fmt.Sprintf("validation_%d", requestErr.StatusCode)
+			entry.EffectKind = requestValidationEffectKind(requestErr.StatusCode)
+			entry.UpstreamStatus = requestErr.StatusCode
+			entry.UpstreamErrorType = "request_validation_error"
+			entry.UpstreamErrorMessage = requestErr.Message
+			entry.DurationMs = time.Since(attemptStartedAt).Milliseconds()
+			entry.RequestMeta = mergeObservationMeta(entry.RequestMeta, map[string]any{
+				"error_phase": "build_request",
+			})
+			r.attachRequestLogArtifacts(entry, prepared, nil, nil)
+			r.logRequestAsync(entry)
+
 			slog.Warn("driver rejected request before upstream",
 				"accountId", acct.ID,
 				"userId", prepared.keyInfo.ID,
@@ -224,7 +251,6 @@ func (r *Relay) executeRelayAttempt(
 		}
 	}
 
-	attemptStartedAt := time.Now()
 	resp, err := r.transport.ClientForAccount(acct).Do(upReq)
 	if err != nil {
 		if r.shouldTraceCompat(prepared) {
@@ -394,8 +420,9 @@ func (r *Relay) finishRelaySuccess(
 
 	var usage *driver.Usage
 	var respBody []byte
+	streamCompleted := true
 	if prepared.input.IsStream {
-		_, usage = drv.StreamResponse(ctx, w, resp)
+		streamCompleted, usage = drv.StreamResponse(ctx, w, resp)
 	} else {
 		var err error
 		respBody, err = io.ReadAll(resp.Body)
@@ -411,11 +438,34 @@ func (r *Relay) finishRelaySuccess(
 
 	entry := r.baseRequestLog(prepared, acct, attempt)
 	entry.Status = "ok"
+	if prepared.input.IsStream && !streamCompleted {
+		entry.Status = "stream_incomplete"
+	}
 	entry.EffectKind = relayEffectKind(effect.Kind)
 	entry.DurationMs = time.Since(attemptStartedAt).Milliseconds()
 	setRequestLogUpstreamRequest(entry, upReq, upstreamReqBody)
 	setRequestLogUpstreamResponse(entry, resp, respBody, &effect)
 	r.attachRequestLogArtifacts(entry, prepared, upstreamReqBody, respBody)
+	if prepared.input.IsStream {
+		entry.RequestMeta = mergeObservationMeta(entry.RequestMeta, map[string]any{
+			"stream_completed": streamCompleted,
+		})
+		if observer, ok := w.(interface{ ClientResponseObservation() map[string]any }); ok {
+			entry.RequestMeta = mergeObservationMeta(entry.RequestMeta, map[string]any{
+				"client_response": observer.ClientResponseObservation(),
+			})
+		}
+		if !streamCompleted {
+			slog.Warn("stream relay ended before completion",
+				"accountId", acct.ID,
+				"userId", prepared.keyInfo.ID,
+				"userName", prepared.keyInfo.Name,
+				"model", prepared.input.Model,
+				"path", prepared.input.Path,
+				"sessionUUID", prepared.sessionUUID,
+			)
+		}
+	}
 	if usage != nil {
 		entry.InputTokens = usage.InputTokens
 		entry.OutputTokens = usage.OutputTokens

--- a/internal/relay/relay_attempt_test.go
+++ b/internal/relay/relay_attempt_test.go
@@ -704,6 +704,22 @@ func TestExecuteRelayAttemptReturnsDriverValidationError(t *testing.T) {
 	if len(driverStub.interpretCalls) != 0 {
 		t.Fatalf("Interpret call count = %d, want 0", len(driverStub.interpretCalls))
 	}
+	logs := waitRequestLogsCount(t, mockStore, 1)
+	if logs[0].Status != "validation_400" {
+		t.Fatalf("request log status = %q, want validation_400", logs[0].Status)
+	}
+	if logs[0].EffectKind != "reject" {
+		t.Fatalf("request log effect kind = %q, want reject", logs[0].EffectKind)
+	}
+	if logs[0].UpstreamStatus != http.StatusBadRequest {
+		t.Fatalf("request log upstream status = %d, want 400", logs[0].UpstreamStatus)
+	}
+	if logs[0].UpstreamErrorType != "request_validation_error" {
+		t.Fatalf("request log upstream error type = %q, want request_validation_error", logs[0].UpstreamErrorType)
+	}
+	if !strings.Contains(logs[0].UpstreamErrorMessage, "does not belong to Claude") {
+		t.Fatalf("request log upstream error message = %q", logs[0].UpstreamErrorMessage)
+	}
 }
 
 func TestRelayStoresAndReusesUserRouteBinding(t *testing.T) {
@@ -846,9 +862,9 @@ func TestRelayRebindsUserRouteBindingWhenStickyAccountUnavailable(t *testing.T) 
 		t.Fatalf("SetUserRouteBinding: %v", err)
 	}
 	p.Observe(accountA.ID, driver.Effect{
-		Kind:          driver.EffectCooldown,
-		Scope:         driver.EffectScopeBucket,
-		CooldownUntil: time.Now().Add(time.Hour),
+		Kind:           driver.EffectCooldown,
+		Scope:          driver.EffectScopeBucket,
+		CooldownUntil:  time.Now().Add(time.Hour),
 		UpstreamStatus: 429,
 	})
 

--- a/internal/relay/relay_flow.go
+++ b/internal/relay/relay_flow.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/yansircc/llm-broker/internal/domain"
 	"github.com/yansircc/llm-broker/internal/driver"
+	"github.com/yansircc/llm-broker/internal/requestid"
 )
 
 func (r *Relay) handleWithDriver(w http.ResponseWriter, req *http.Request, drv driver.ExecutionDriver, surface domain.Surface) {
+	req = requestid.Ensure(req, w)
 	ctx := req.Context()
 
 	prepared, handled := r.prepareRelayRequest(w, req, drv, surface)

--- a/internal/relay/relay_observe.go
+++ b/internal/relay/relay_observe.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/yansircc/llm-broker/internal/requestid"
 )
 
 const compatClientMetaHeader = "X-Broker-Compat-Client-Meta"
@@ -110,6 +112,10 @@ func requestMeta(prepared *preparedRelayRequest) json.RawMessage {
 	rawBody := requestLogClientBody(prepared)
 	meta := map[string]any{
 		"stream": prepared.input.IsStream,
+		"phase":  "relay_attempt",
+	}
+	if id := strings.TrimSpace(requestLogClientHeaders(prepared).Get(requestid.Header)); id != "" {
+		meta["request_id"] = id
 	}
 	if keys := observationKeys(body); len(keys) > 0 {
 		meta["top_level_keys"] = keys

--- a/internal/requestid/requestid.go
+++ b/internal/requestid/requestid.go
@@ -1,0 +1,53 @@
+package requestid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+)
+
+type contextKey string
+
+const (
+	Header            = "X-Broker-Request-Id"
+	key    contextKey = "brokerRequestID"
+)
+
+var seq atomic.Uint64
+
+func Get(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	value, _ := ctx.Value(key).(string)
+	return strings.TrimSpace(value)
+}
+
+func FromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(Get(r.Context())); id != "" {
+		return id
+	}
+	return strings.TrimSpace(r.Header.Get(Header))
+}
+
+func Ensure(r *http.Request, w http.ResponseWriter) *http.Request {
+	if r == nil {
+		return r
+	}
+	id := FromRequest(r)
+	if id == "" {
+		id = fmt.Sprintf("req-%d", seq.Add(1))
+	}
+	if w != nil {
+		w.Header().Set(Header, id)
+	}
+	clone := r.Clone(context.WithValue(r.Context(), key, id))
+	clone.Header = r.Header.Clone()
+	clone.Header.Set(Header, id)
+	return clone
+}

--- a/internal/server/compat_lifecycle.go
+++ b/internal/server/compat_lifecycle.go
@@ -1,0 +1,291 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yansircc/llm-broker/internal/auth"
+	"github.com/yansircc/llm-broker/internal/domain"
+	"github.com/yansircc/llm-broker/internal/requestid"
+)
+
+type observedResponseWriter struct {
+	dst     http.ResponseWriter
+	status  int
+	written int
+	err     error
+}
+
+func newObservedResponseWriter(dst http.ResponseWriter) *observedResponseWriter {
+	if existing, ok := dst.(*observedResponseWriter); ok {
+		return existing
+	}
+	return &observedResponseWriter{dst: dst}
+}
+
+func (w *observedResponseWriter) Header() http.Header {
+	return w.dst.Header()
+}
+
+func (w *observedResponseWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+	w.dst.WriteHeader(status)
+}
+
+func (w *observedResponseWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.dst.Write(p)
+	w.written += n
+	if err != nil && w.err == nil {
+		w.err = err
+	}
+	return n, err
+}
+
+func (w *observedResponseWriter) Flush() {
+	if flusher, ok := w.dst.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *observedResponseWriter) statusCode() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *observedResponseWriter) observation() map[string]any {
+	if w == nil {
+		return nil
+	}
+	meta := map[string]any{
+		"http_status":   w.statusCode(),
+		"written_bytes": w.written,
+	}
+	if contentType := strings.TrimSpace(w.Header().Get("Content-Type")); contentType != "" {
+		meta["content_type"] = contentType
+	}
+	if w.err != nil {
+		meta["write_error"] = w.err.Error()
+	}
+	return meta
+}
+
+func (s *Server) logCompatFailureRequest(
+	r *http.Request,
+	rawBody []byte,
+	req *compatOpenAIChatRequest,
+	target *compatTarget,
+	phase string,
+	ow *observedResponseWriter,
+	status string,
+	effectKind string,
+	duration time.Duration,
+	message string,
+	extra map[string]any,
+) {
+	if s == nil || s.store == nil || r == nil {
+		return
+	}
+
+	entry := &domain.RequestLog{
+		Surface:           string(domain.SurfaceCompat),
+		Path:              r.URL.Path,
+		Status:            status,
+		EffectKind:        effectKind,
+		RequestBytes:      len(rawBody),
+		DurationMs:        duration.Milliseconds(),
+		CreatedAt:         time.Now().UTC(),
+		ClientHeaders:     compatLifecycleHeaders(r.Header),
+		ClientBodyExcerpt: compatLifecycleBodyExcerpt(rawBody),
+	}
+
+	if ki := auth.GetKeyInfo(r.Context()); ki != nil {
+		entry.UserID = ki.ID
+	}
+	if req != nil {
+		entry.Model = strings.TrimSpace(req.Model)
+	}
+	if target != nil {
+		entry.Provider = string(target.provider)
+		if strings.TrimSpace(target.requestedModel) != "" {
+			entry.Model = target.requestedModel
+		}
+	}
+
+	meta := map[string]any{
+		"phase": phase,
+	}
+	if id := requestid.FromRequest(r); id != "" {
+		meta["request_id"] = id
+	}
+	if req != nil {
+		meta["stream"] = req.Stream
+		if model := strings.TrimSpace(req.Model); model != "" {
+			meta["requested_model"] = model
+		}
+	}
+	if target != nil {
+		meta["relay_path"] = target.relayPath
+		meta["provider"] = string(target.provider)
+		if target.stream {
+			meta["translated_stream"] = true
+		}
+	}
+	if compatMeta := compatLifecycleCompatClient(rawBody); len(compatMeta) > 0 {
+		meta["compat_client"] = compatMeta
+	}
+	if owMeta := ow.observation(); len(owMeta) > 0 {
+		meta["client_response"] = owMeta
+	}
+	if message = strings.TrimSpace(message); message != "" {
+		meta["error_message"] = message
+	}
+	for key, value := range extra {
+		if compatLifecycleHasValue(value) {
+			meta[key] = value
+		}
+	}
+	entry.RequestMeta = compatLifecycleMarshal(meta)
+
+	go func() {
+		if err := s.store.InsertRequestLog(context.Background(), entry); err != nil {
+			slog.Warn("compat lifecycle request log failed", "status", status, "phase", phase, "error", err)
+		}
+	}()
+}
+
+func compatLifecycleHeaders(h http.Header) json.RawMessage {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for key, values := range h {
+		if len(values) == 0 {
+			continue
+		}
+		lower := strings.ToLower(key)
+		if lower == "accept" ||
+			lower == "content-type" ||
+			lower == "user-agent" ||
+			lower == "cf-ray" ||
+			lower == "x-stainless-retry-count" ||
+			lower == strings.ToLower(requestid.Header) ||
+			strings.HasPrefix(lower, "x-broker-") {
+			out[key] = strings.Join(values, ", ")
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(out)
+	if err != nil || string(data) == "{}" {
+		return nil
+	}
+	return json.RawMessage(data)
+}
+
+func compatLifecycleBodyExcerpt(body []byte) string {
+	text, _ := formatCompatTraceBody(body)
+	return text
+}
+
+func compatLifecycleCompatClient(rawBody []byte) map[string]any {
+	if meta := buildCompatClientMeta(rawBody); meta != "" {
+		var value map[string]any
+		if json.Unmarshal([]byte(meta), &value) == nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func compatLifecycleMarshal(value map[string]any) json.RawMessage {
+	if len(value) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil || string(data) == "{}" {
+		return nil
+	}
+	return json.RawMessage(data)
+}
+
+func compatLifecycleHasValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func (s *Server) logCompatCompletion(
+	r *http.Request,
+	req *compatOpenAIChatRequest,
+	target *compatTarget,
+	ow *observedResponseWriter,
+	duration time.Duration,
+	outcome string,
+	extra map[string]any,
+) {
+	if r == nil {
+		return
+	}
+	attrs := []any{
+		"requestId", requestid.FromRequest(r),
+		"path", r.URL.Path,
+		"outcome", outcome,
+		"durationMs", duration.Milliseconds(),
+		"clientResponse", ow.observation(),
+	}
+	if ki := auth.GetKeyInfo(r.Context()); ki != nil {
+		attrs = append(attrs, "userId", ki.ID, "userName", ki.Name)
+	}
+	if req != nil {
+		if model := strings.TrimSpace(req.Model); model != "" {
+			attrs = append(attrs, "requestedModel", model)
+		}
+		attrs = append(attrs, "stream", req.Stream)
+	}
+	if target != nil {
+		attrs = append(attrs,
+			"provider", target.provider,
+			"relayPath", target.relayPath,
+			"translatedStream", target.stream,
+		)
+	}
+	for key, value := range extra {
+		if compatLifecycleHasValue(value) {
+			attrs = append(attrs, key, value)
+		}
+	}
+	if outcome == "ok" {
+		slog.Info("compat request completed", attrs...)
+		return
+	}
+	slog.Warn("compat request completed", attrs...)
+}
+
+func compatFailureStatusCode(status int) string {
+	if status <= 0 {
+		return "compat_failed"
+	}
+	return "compat_" + strconv.Itoa(status)
+}

--- a/internal/server/compat_openai_chat.go
+++ b/internal/server/compat_openai_chat.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yansircc/llm-broker/internal/config"
 	"github.com/yansircc/llm-broker/internal/domain"
 	relaypkg "github.com/yansircc/llm-broker/internal/relay"
+	"github.com/yansircc/llm-broker/internal/requestid"
 )
 
 func (s *Server) handleCompatListModels(w http.ResponseWriter, r *http.Request) {
@@ -45,44 +46,86 @@ func (s *Server) handleCompatListModels(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, compatRequestBodyLimitBytes(s.cfg))
+	startedAt := time.Now()
+	ow := newObservedResponseWriter(w)
+	r = requestid.Ensure(r, ow)
+	r.Body = http.MaxBytesReader(ow, r.Body, compatRequestBodyLimitBytes(s.cfg))
+
+	var rawBody []byte
+	var req compatOpenAIChatRequest
+	var target *compatTarget
+	reqRef := func() *compatOpenAIChatRequest {
+		if strings.TrimSpace(req.Model) == "" && len(req.Messages) == 0 && !req.Stream {
+			return nil
+		}
+		return &req
+	}
+	logFailure := func(phase, status, effectKind, message string, extra map[string]any) {
+		s.logCompatFailureRequest(r, rawBody, reqRef(), target, phase, ow, status, effectKind, time.Since(startedAt), message, extra)
+		s.logCompatCompletion(r, reqRef(), target, ow, time.Since(startedAt), "error", extra)
+	}
 
 	releaseCompatSlot := func() {}
 	if ki := auth.GetKeyInfo(r.Context()); ki != nil && !ki.IsAdmin {
 		release, err := s.compatLimiter.Acquire(ki.ID, time.Now())
 		if err != nil {
-			writeCompatOpenAIError(w, http.StatusTooManyRequests, "rate_limit_error", err.Error())
+			writeCompatOpenAIError(ow, http.StatusTooManyRequests, "rate_limit_error", err.Error())
+			logFailure("compat_preflight", compatFailureStatusCode(ow.statusCode()), "overload", err.Error(), map[string]any{
+				"error_type": "rate_limit_error",
+			})
 			return
 		}
 		releaseCompatSlot = release
 	}
 	defer releaseCompatSlot()
 
-	rawBody, err := io.ReadAll(r.Body)
+	var err error
+	rawBody, err = io.ReadAll(r.Body)
 	if err != nil {
-		writeCompatOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
+		writeCompatOpenAIError(ow, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
+		logFailure("compat_preflight", compatFailureStatusCode(ow.statusCode()), "reject", "invalid JSON body", map[string]any{
+			"error_type": "invalid_request_error",
+		})
 		return
 	}
 
-	var req compatOpenAIChatRequest
 	if err := json.NewDecoder(bytes.NewReader(rawBody)).Decode(&req); err != nil {
-		writeCompatOpenAIError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
+		writeCompatOpenAIError(ow, http.StatusBadRequest, "invalid_request_error", "invalid JSON body")
+		logFailure("compat_preflight", compatFailureStatusCode(ow.statusCode()), "reject", "invalid JSON body", map[string]any{
+			"error_type": "invalid_request_error",
+		})
 		return
 	}
 
-	target, err := buildCompatTarget(&req)
+	target, err = buildCompatTarget(&req)
 	if err != nil {
-		writeCompatOpenAIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		writeCompatOpenAIError(ow, http.StatusBadRequest, "invalid_request_error", err.Error())
+		logFailure("compat_preflight", compatFailureStatusCode(ow.statusCode()), "reject", err.Error(), map[string]any{
+			"error_type": "invalid_request_error",
+		})
 		return
 	}
 	if s.catalogDrivers[target.provider] == nil {
-		writeCompatOpenAIError(w, http.StatusServiceUnavailable, "server_error", "provider compat surface is unavailable")
+		writeCompatOpenAIError(ow, http.StatusServiceUnavailable, "server_error", "provider compat surface is unavailable")
+		logFailure("compat_preflight", compatFailureStatusCode(ow.statusCode()), "server_error", "provider compat surface is unavailable", map[string]any{
+			"error_type": "server_error",
+		})
 		return
 	}
 
+	slog.Info("compat request translated",
+		"requestId", requestid.FromRequest(r),
+		"path", r.URL.Path,
+		"provider", target.provider,
+		"requestedModel", strings.TrimSpace(req.Model),
+		"translatedModel", target.requestedModel,
+		"relayPath", target.relayPath,
+		"stream", req.Stream,
+	)
+
 	traceID := ""
 	if s.cfg != nil && s.cfg.TraceCompat {
-		traceID = s.nextCompatTraceID()
+		traceID = requestid.FromRequest(r)
 		s.logCompatTranslationTrace(traceID, rawBody, r.URL.Path, target.relayPath, target.upstreamBody)
 	}
 
@@ -121,9 +164,19 @@ func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	}
 
 	if target.stream {
-		streamWriter := target.newStreamWriter(w, target.requestedModel)
+		streamWriter := target.newStreamWriter(ow, target.requestedModel)
 		s.relay.HandleProviderSurface(target.provider, domain.SurfaceCompat).ServeHTTP(streamWriter, relayReq)
 		streamWriter.finalize()
+		streamMeta := streamWriter.ClientResponseObservation()
+		if !streamWriter.completed() && ow.statusCode() == http.StatusOK {
+			logFailure("compat_final", "compat_stream_incomplete", "stream_incomplete", "stream response did not complete cleanly", map[string]any{
+				"stream_writer": streamMeta,
+			})
+			return
+		}
+		s.logCompatCompletion(r, &req, target, ow, time.Since(startedAt), "ok", map[string]any{
+			"stream_writer": streamMeta,
+		})
 		return
 	}
 
@@ -135,16 +188,26 @@ func (s *Server) handleCompatOpenAIChatCompletions(w http.ResponseWriter, r *htt
 		status = http.StatusOK
 	}
 	if status != http.StatusOK {
-		writeCompatOpenAIUpstreamError(w, status, capture.body.Bytes())
+		writeCompatOpenAIUpstreamError(ow, status, capture.body.Bytes())
+		s.logCompatCompletion(r, &req, target, ow, time.Since(startedAt), "error", map[string]any{
+			"relay_status": status,
+		})
 		return
 	}
 
 	openAIResp, err := target.convertResponse(capture.body.Bytes(), target.requestedModel)
 	if err != nil {
-		writeCompatOpenAIError(w, http.StatusBadGateway, "server_error", "failed to convert compat response")
+		writeCompatOpenAIError(ow, http.StatusBadGateway, "server_error", "failed to convert compat response")
+		logFailure("compat_final", compatFailureStatusCode(ow.statusCode()), "server_error", "failed to convert compat response", map[string]any{
+			"relay_status":  status,
+			"convert_error": err.Error(),
+		})
 		return
 	}
-	writeJSON(w, http.StatusOK, openAIResp)
+	writeJSON(ow, http.StatusOK, openAIResp)
+	s.logCompatCompletion(r, &req, target, ow, time.Since(startedAt), "ok", map[string]any{
+		"relay_status": status,
+	})
 }
 
 func buildCompatTarget(req *compatOpenAIChatRequest) (*compatTarget, error) {
@@ -222,6 +285,32 @@ func compatClaudeUpstreamHeaders(model string) http.Header {
 	return headers
 }
 
+var compatClaudeModelAliases = map[string]string{
+	"claude-haiku-4.5":           "claude-haiku-4-5",
+	"claude-opus-4.0":            "claude-opus-4",
+	"claude-opus-4-0":            "claude-opus-4",
+	"claude-opus-4.1":            "claude-opus-4-1",
+	"claude-opus-4-1-20250805":   "claude-opus-4-1",
+	"claude-opus-4.5":            "claude-opus-4-5",
+	"claude-opus-4-5-20251101":   "claude-opus-4-5",
+	"claude-opus-4.6":            "claude-opus-4-6",
+	"claude-opus-4-20250514":     "claude-opus-4",
+	"claude-sonnet-4.0":          "claude-sonnet-4",
+	"claude-sonnet-4-0":          "claude-sonnet-4",
+	"claude-sonnet-4.5":          "claude-sonnet-4-5",
+	"claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+	"claude-sonnet-4.6":          "claude-sonnet-4-6",
+	"claude-sonnet-4-20250514":   "claude-sonnet-4-6",
+}
+
+func compatCanonicalClaudeModel(model string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(model))
+	if canonical, ok := compatClaudeModelAliases[trimmed]; ok {
+		return canonical
+	}
+	return trimmed
+}
+
 func resolveCompatModel(model string) (domain.Provider, string, string, error) {
 	trimmed := strings.TrimSpace(model)
 	if trimmed == "" {
@@ -237,6 +326,7 @@ func resolveCompatModel(model string) (domain.Provider, string, string, error) {
 
 	switch {
 	case providerPrefix == "claude" || providerPrefix == "anthropic" || (providerPrefix == "" && strings.HasPrefix(baseModel, "claude-")):
+		baseModel = compatCanonicalClaudeModel(baseModel)
 		if !strings.HasPrefix(baseModel, "claude-") {
 			return "", "", "", errCompat("model must be a claude model, e.g. claude/claude-sonnet-4-5")
 		}

--- a/internal/server/compat_openai_chat_test.go
+++ b/internal/server/compat_openai_chat_test.go
@@ -165,6 +165,32 @@ func TestCompatOpenAIChatToClaudeRequest_ModernEnvelope(t *testing.T) {
 	}
 }
 
+func TestCompatOpenAIChatToClaudeRequest_ModernEnvelopeAlias(t *testing.T) {
+	req := &compatOpenAIChatRequest{
+		Model: "claude/claude-sonnet-4-20250514",
+		Messages: []compatMessage{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	got, requestedModel, err := compatOpenAIChatToClaudeRequest(req)
+	if err != nil {
+		t.Fatalf("compatOpenAIChatToClaudeRequest() error = %v", err)
+	}
+	if requestedModel != "claude/claude-sonnet-4-6" {
+		t.Fatalf("requestedModel = %q", requestedModel)
+	}
+	if got.Model != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q", got.Model)
+	}
+	if got.OutputConfig == nil || got.OutputConfig.Effort != "medium" {
+		t.Fatalf("output_config = %#v", got.OutputConfig)
+	}
+	if got.Thinking == nil || got.Thinking.Type != "adaptive" {
+		t.Fatalf("thinking = %#v", got.Thinking)
+	}
+}
+
 func TestResolveCompatModelAliases(t *testing.T) {
 	tests := []struct {
 		model         string
@@ -175,6 +201,12 @@ func TestResolveCompatModelAliases(t *testing.T) {
 		{"claude/claude-sonnet-4-5", domain.ProviderClaude, "claude-sonnet-4-5", "claude/claude-sonnet-4-5"},
 		{"anthropic/claude-sonnet-4-5", domain.ProviderClaude, "claude-sonnet-4-5", "claude/claude-sonnet-4-5"},
 		{"claude-sonnet-4-5", domain.ProviderClaude, "claude-sonnet-4-5", "claude/claude-sonnet-4-5"},
+		{"anthropic/claude-sonnet-4.5", domain.ProviderClaude, "claude-sonnet-4-5", "claude/claude-sonnet-4-5"},
+		{"claude-sonnet-4-5-20250929", domain.ProviderClaude, "claude-sonnet-4-5", "claude/claude-sonnet-4-5"},
+		{"anthropic/claude-opus-4.6", domain.ProviderClaude, "claude-opus-4-6", "claude/claude-opus-4-6"},
+		{"claude-opus-4-1-20250805", domain.ProviderClaude, "claude-opus-4-1", "claude/claude-opus-4-1"},
+		{"anthropic/claude-haiku-4.5", domain.ProviderClaude, "claude-haiku-4-5", "claude/claude-haiku-4-5"},
+		{"claude-sonnet-4-20250514", domain.ProviderClaude, "claude-sonnet-4-6", "claude/claude-sonnet-4-6"},
 		{"gemini/gemini-2.5-flash", domain.ProviderGemini, "gemini-2.5-flash", "gemini/gemini-2.5-flash"},
 		{"google/gemini-2.5-pro", domain.ProviderGemini, "gemini-2.5-pro", "gemini/gemini-2.5-pro"},
 		{"gemini-2.5-pro", domain.ProviderGemini, "gemini-2.5-pro", "gemini/gemini-2.5-pro"},
@@ -1086,6 +1118,135 @@ func TestHandleCompatOpenAIChatCompletions_RateLimited(t *testing.T) {
 	if !strings.Contains(second.Body.String(), "rate limit") {
 		t.Fatalf("second body = %s", second.Body.String())
 	}
+
+	logs := waitForCompatRequestLogsCount(t, srv, 2)
+	entry := findCompatRequestLogByStatus(t, logs, "compat_429")
+	if entry.Status != "compat_429" {
+		t.Fatalf("entry.Status = %q, want compat_429", entry.Status)
+	}
+	if entry.EffectKind != "overload" {
+		t.Fatalf("entry.EffectKind = %q, want overload", entry.EffectKind)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(entry.RequestMeta, &meta); err != nil {
+		t.Fatalf("Unmarshal RequestMeta: %v", err)
+	}
+	if meta["phase"] != "compat_preflight" {
+		t.Fatalf("phase = %#v, want compat_preflight", meta["phase"])
+	}
+}
+
+func TestHandleCompatOpenAIChatCompletions_LogsConvertFailure(t *testing.T) {
+	upstreamClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			respBody := `{"id":"msg_bad","model":"claude-sonnet-4-5","content":"wrong-shape"}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+			}, nil
+		}),
+	}
+	srv := newCompatTestServer(t, upstreamClient)
+
+	reqBody := `{
+		"model":"claude/claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/compat/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), auth.KeyInfoKey, &auth.KeyInfo{ID: "user-1", Name: "test"})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	srv.handleCompatOpenAIChatCompletions(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadGateway, w.Body.String())
+	}
+
+	logs := waitForCompatRequestLogsCount(t, srv, 2)
+	entry := findCompatRequestLogByStatus(t, logs, "compat_502")
+	if entry.Status != "compat_502" {
+		t.Fatalf("entry.Status = %q, want compat_502", entry.Status)
+	}
+	if entry.EffectKind != "server_error" {
+		t.Fatalf("entry.EffectKind = %q, want server_error", entry.EffectKind)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(entry.RequestMeta, &meta); err != nil {
+		t.Fatalf("Unmarshal RequestMeta: %v", err)
+	}
+	if meta["phase"] != "compat_final" {
+		t.Fatalf("phase = %#v, want compat_final", meta["phase"])
+	}
+}
+
+func TestHandleCompatOpenAIChatCompletions_StreamIncompleteWritesLifecycleFailure(t *testing.T) {
+	upstreamClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			respBody := strings.Join([]string{
+				`event: message_start`,
+				`data: {"type":"message_start","message":{"id":"msg_stream_incomplete","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5"}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+				``,
+				`event: message_delta`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`,
+				``,
+			}, "\n")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respBody)),
+			}, nil
+		}),
+	}
+	srv := newCompatTestServer(t, upstreamClient)
+
+	reqBody := `{
+		"model":"claude/claude-sonnet-4-5",
+		"stream": true,
+		"messages":[{"role":"user","content":"hello"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/compat/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), auth.KeyInfoKey, &auth.KeyInfo{ID: "user-1", Name: "test"})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	srv.handleCompatOpenAIChatCompletions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	logs := waitForCompatRequestLogsCount(t, srv, 2)
+	last := findCompatRequestLogByStatus(t, logs, "compat_stream_incomplete")
+	if last.Status != "compat_stream_incomplete" {
+		t.Fatalf("entry.Status = %q, want compat_stream_incomplete", last.Status)
+	}
+	if last.EffectKind != "stream_incomplete" {
+		t.Fatalf("entry.EffectKind = %q, want stream_incomplete", last.EffectKind)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(last.RequestMeta, &meta); err != nil {
+		t.Fatalf("Unmarshal RequestMeta: %v", err)
+	}
+	if meta["phase"] != "compat_final" {
+		t.Fatalf("phase = %#v, want compat_final", meta["phase"])
+	}
+	streamWriter, ok := meta["stream_writer"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_writer = %#v, want object", meta["stream_writer"])
+	}
+	if streamWriter["delivery_completed"] != false {
+		t.Fatalf("delivery_completed = %#v, want false", streamWriter["delivery_completed"])
+	}
+	if streamWriter["synthetic_done"] != true {
+		t.Fatalf("synthetic_done = %#v, want true", streamWriter["synthetic_done"])
+	}
 }
 
 func TestHandleCompatOpenAIChatCompletions_TraceLogsRawClientBody(t *testing.T) {
@@ -1164,6 +1325,36 @@ func waitForCompatRequestLog(t *testing.T, srv *Server) *domain.RequestLog {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("request log was not persisted in time")
+	return nil
+}
+
+func waitForCompatRequestLogsCount(t *testing.T, srv *Server, want int) []*domain.RequestLog {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		logs, total, err := srv.store.QueryRequestLogs(context.Background(), domain.RequestLogQuery{Limit: want + 4})
+		if err != nil {
+			t.Fatalf("QueryRequestLogs() error = %v", err)
+		}
+		if total >= want && len(logs) >= want {
+			return logs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("request logs did not reach count %d in time", want)
+	return nil
+}
+
+func findCompatRequestLogByStatus(t *testing.T, logs []*domain.RequestLog, want string) *domain.RequestLog {
+	t.Helper()
+
+	for _, entry := range logs {
+		if entry.Status == want {
+			return entry
+		}
+	}
+	t.Fatalf("request logs do not contain status %q", want)
 	return nil
 }
 

--- a/internal/server/compat_openai_stream.go
+++ b/internal/server/compat_openai_stream.go
@@ -24,6 +24,13 @@ type compatOpenAIStreamWriter struct {
 	chunkID       string
 	roleSent      bool
 	doneSent      bool
+
+	chunksEmitted      int
+	contentChunks      int
+	terminalSignalSeen bool
+	syntheticDone      bool
+	downstreamBytes    int
+	downstreamErr      error
 }
 
 type compatGeminiStreamWriter struct {
@@ -41,6 +48,13 @@ type compatGeminiStreamWriter struct {
 	doneSent     bool
 	roleSent     bool
 	chunkID      string
+
+	chunksEmitted      int
+	contentChunks      int
+	terminalSignalSeen bool
+	syntheticDone      bool
+	downstreamBytes    int
+	downstreamErr      error
 }
 
 func newCompatOpenAIStreamWriter(dst http.ResponseWriter, requestedModel string) *compatOpenAIStreamWriter {
@@ -70,6 +84,9 @@ func (w *compatOpenAIStreamWriter) Write(p []byte) (int, error) {
 	if w.status == 0 {
 		w.status = http.StatusOK
 	}
+	if w.downstreamErr != nil {
+		return len(p), w.downstreamErr
+	}
 	if w.status != http.StatusOK {
 		_, _ = w.rawErrorBody.Write(p)
 		return len(p), nil
@@ -81,7 +98,9 @@ func (w *compatOpenAIStreamWriter) Write(p []byte) (int, error) {
 		if !ok {
 			break
 		}
-		w.handleClaudeStreamLine(line)
+		if !w.handleClaudeStreamLine(line) {
+			return len(p), w.downstreamErr
+		}
 	}
 	return len(p), nil
 }
@@ -103,16 +122,16 @@ func (w *compatOpenAIStreamWriter) nextLine() (string, bool) {
 	return line, true
 }
 
-func (w *compatOpenAIStreamWriter) handleClaudeStreamLine(line string) {
+func (w *compatOpenAIStreamWriter) handleClaudeStreamLine(line string) bool {
 	if line == "" {
-		return
+		return true
 	}
 	if strings.HasPrefix(line, "event: ") {
 		w.lastEventType = strings.TrimPrefix(line, "event: ")
-		return
+		return true
 	}
 	if !strings.HasPrefix(line, "data: ") {
-		return
+		return true
 	}
 
 	payload := strings.TrimPrefix(line, "data: ")
@@ -128,7 +147,7 @@ func (w *compatOpenAIStreamWriter) handleClaudeStreamLine(line string) {
 		}
 		if !w.roleSent {
 			w.roleSent = true
-			w.emitChunk(compatOpenAIChatDelta{Role: "assistant"}, nil)
+			return w.emitChunk(compatOpenAIChatDelta{Role: "assistant"}, nil)
 		}
 
 	case "content_block_delta":
@@ -139,10 +158,10 @@ func (w *compatOpenAIStreamWriter) handleClaudeStreamLine(line string) {
 			} `json:"delta"`
 		}
 		if json.Unmarshal([]byte(payload), &event) != nil {
-			return
+			return true
 		}
 		if event.Delta.Type == "text_delta" && event.Delta.Text != "" {
-			w.emitChunk(compatOpenAIChatDelta{Content: event.Delta.Text}, nil)
+			return w.emitChunk(compatOpenAIChatDelta{Content: event.Delta.Text}, nil)
 		}
 
 	case "message_delta":
@@ -152,17 +171,19 @@ func (w *compatOpenAIStreamWriter) handleClaudeStreamLine(line string) {
 			} `json:"delta"`
 		}
 		if json.Unmarshal([]byte(payload), &event) != nil {
-			return
+			return true
 		}
 		if strings.TrimSpace(event.Delta.StopReason) == "" {
-			return
+			return true
 		}
 		finishReason := compatClaudeFinishReason(event.Delta.StopReason)
-		w.emitChunk(compatOpenAIChatDelta{}, &finishReason)
+		return w.emitChunk(compatOpenAIChatDelta{}, &finishReason)
 
 	case "message_stop":
-		w.emitDone()
+		w.terminalSignalSeen = true
+		return w.emitDone(false)
 	}
+	return true
 }
 
 func (w *compatOpenAIStreamWriter) ensureSuccessHeaders() {
@@ -183,7 +204,7 @@ func (w *compatOpenAIStreamWriter) streamChunkID() string {
 	return "chatcmpl-compat"
 }
 
-func (w *compatOpenAIStreamWriter) emitChunk(delta compatOpenAIChatDelta, finishReason *string) {
+func (w *compatOpenAIStreamWriter) emitChunk(delta compatOpenAIChatDelta, finishReason *string) bool {
 	w.ensureSuccessHeaders()
 
 	body, err := json.Marshal(compatOpenAIChatStreamChunk{
@@ -200,26 +221,43 @@ func (w *compatOpenAIStreamWriter) emitChunk(delta compatOpenAIChatDelta, finish
 		},
 	})
 	if err != nil {
-		return
+		return true
 	}
-
-	_, _ = w.dst.Write([]byte("data: "))
-	_, _ = w.dst.Write(body)
-	_, _ = w.dst.Write([]byte("\n\n"))
+	if delta.Content != "" {
+		w.contentChunks++
+	}
+	w.chunksEmitted++
+	if !w.writeDownstream([]byte("data: ")) {
+		return false
+	}
+	if !w.writeDownstream(body) {
+		return false
+	}
+	if !w.writeDownstream([]byte("\n\n")) {
+		return false
+	}
 	w.Flush()
+	return w.downstreamErr == nil
 }
 
-func (w *compatOpenAIStreamWriter) emitDone() {
+func (w *compatOpenAIStreamWriter) emitDone(synthetic bool) bool {
 	if w.doneSent {
-		return
+		return w.downstreamErr == nil
 	}
 	w.ensureSuccessHeaders()
-	_, _ = w.dst.Write([]byte("data: [DONE]\n\n"))
+	w.syntheticDone = synthetic
+	if !w.writeDownstream([]byte("data: [DONE]\n\n")) {
+		return false
+	}
 	w.Flush()
 	w.doneSent = true
+	return w.downstreamErr == nil
 }
 
 func (w *compatOpenAIStreamWriter) finalize() {
+	if w.downstreamErr != nil {
+		return
+	}
 	if w.status != 0 && w.status != http.StatusOK {
 		writeCompatOpenAIUpstreamError(w.dst, w.status, compatExtractErrorBody(w.rawErrorBody.Bytes()))
 		return
@@ -229,10 +267,51 @@ func (w *compatOpenAIStreamWriter) finalize() {
 		line := strings.TrimRight(w.lineBuf.String(), "\r\n")
 		w.lineBuf.Reset()
 		if line != "" {
-			w.handleClaudeStreamLine(line)
+			if !w.handleClaudeStreamLine(line) {
+				return
+			}
 		}
 	}
-	w.emitDone()
+	_ = w.emitDone(!w.terminalSignalSeen)
+}
+
+func (w *compatOpenAIStreamWriter) writeDownstream(p []byte) bool {
+	n, err := w.dst.Write(p)
+	w.downstreamBytes += n
+	if err != nil && w.downstreamErr == nil {
+		w.downstreamErr = err
+	}
+	return err == nil
+}
+
+func (w *compatOpenAIStreamWriter) completed() bool {
+	return (w.status == 0 || w.status == http.StatusOK) && w.downstreamErr == nil && w.terminalSignalSeen && w.doneSent
+}
+
+func (w *compatOpenAIStreamWriter) ClientResponseObservation() map[string]any {
+	meta := map[string]any{
+		"http_status":          w.statusOrOK(),
+		"headers_written":      w.headersWritten,
+		"chunks_emitted":       w.chunksEmitted,
+		"content_chunks":       w.contentChunks,
+		"role_sent":            w.roleSent,
+		"done_sent":            w.doneSent,
+		"terminal_signal_seen": w.terminalSignalSeen,
+		"synthetic_done":       w.syntheticDone,
+		"downstream_bytes":     w.downstreamBytes,
+		"delivery_completed":   w.completed(),
+	}
+	if w.downstreamErr != nil {
+		meta["downstream_error"] = w.downstreamErr.Error()
+	}
+	return meta
+}
+
+func (w *compatOpenAIStreamWriter) statusOrOK() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
 }
 
 func newCompatGeminiStreamWriter(dst http.ResponseWriter, requestedModel string) *compatGeminiStreamWriter {
@@ -262,6 +341,9 @@ func (w *compatGeminiStreamWriter) Write(p []byte) (int, error) {
 	if w.status == 0 {
 		w.status = http.StatusOK
 	}
+	if w.downstreamErr != nil {
+		return len(p), w.downstreamErr
+	}
 	if w.status != http.StatusOK {
 		_, _ = w.rawErrorBody.Write(p)
 		return len(p), nil
@@ -273,7 +355,9 @@ func (w *compatGeminiStreamWriter) Write(p []byte) (int, error) {
 		if !ok {
 			break
 		}
-		w.handleGeminiStreamLine(line)
+		if !w.handleGeminiStreamLine(line) {
+			return len(p), w.downstreamErr
+		}
 	}
 	return len(p), nil
 }
@@ -295,31 +379,33 @@ func (w *compatGeminiStreamWriter) nextLine() (string, bool) {
 	return line, true
 }
 
-func (w *compatGeminiStreamWriter) handleGeminiStreamLine(line string) {
+func (w *compatGeminiStreamWriter) handleGeminiStreamLine(line string) bool {
 	if line == "" || !strings.HasPrefix(line, "data: ") {
-		return
+		return true
 	}
 	payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
 	if payload == "" || payload == "[DONE]" {
-		w.emitDone()
-		return
+		w.terminalSignalSeen = true
+		return w.emitDone(false)
 	}
 
 	resp, err := compatParseGeminiResponse([]byte(payload))
 	if err != nil || resp == nil {
-		return
+		return true
 	}
 	if strings.TrimSpace(resp.ResponseID) != "" {
 		w.chunkID = resp.ResponseID
 	}
 	if len(resp.Candidates) == 0 {
-		return
+		return true
 	}
 	candidate := resp.Candidates[0]
 	if candidate.Content != nil {
 		if !w.roleSent {
 			w.roleSent = true
-			w.emitChunk(compatOpenAIChatDelta{Role: "assistant"}, nil)
+			if !w.emitChunk(compatOpenAIChatDelta{Role: "assistant"}, nil) {
+				return false
+			}
 		}
 
 		var text strings.Builder
@@ -329,14 +415,18 @@ func (w *compatGeminiStreamWriter) handleGeminiStreamLine(line string) {
 			}
 		}
 		if text.Len() > 0 {
-			w.emitChunk(compatOpenAIChatDelta{Content: text.String()}, nil)
+			if !w.emitChunk(compatOpenAIChatDelta{Content: text.String()}, nil) {
+				return false
+			}
 		}
 	}
 
 	if strings.TrimSpace(candidate.FinishReason) != "" {
 		finishReason := compatGeminiFinishReason(candidate.FinishReason)
-		w.emitChunk(compatOpenAIChatDelta{}, &finishReason)
+		w.terminalSignalSeen = true
+		return w.emitChunk(compatOpenAIChatDelta{}, &finishReason)
 	}
+	return true
 }
 
 func (w *compatGeminiStreamWriter) ensureSuccessHeaders() {
@@ -357,7 +447,7 @@ func (w *compatGeminiStreamWriter) streamChunkID() string {
 	return "chatcmpl-compat"
 }
 
-func (w *compatGeminiStreamWriter) emitChunk(delta compatOpenAIChatDelta, finishReason *string) {
+func (w *compatGeminiStreamWriter) emitChunk(delta compatOpenAIChatDelta, finishReason *string) bool {
 	w.ensureSuccessHeaders()
 
 	body, err := json.Marshal(compatOpenAIChatStreamChunk{
@@ -374,26 +464,43 @@ func (w *compatGeminiStreamWriter) emitChunk(delta compatOpenAIChatDelta, finish
 		},
 	})
 	if err != nil {
-		return
+		return true
 	}
-
-	_, _ = w.dst.Write([]byte("data: "))
-	_, _ = w.dst.Write(body)
-	_, _ = w.dst.Write([]byte("\n\n"))
+	if delta.Content != "" {
+		w.contentChunks++
+	}
+	w.chunksEmitted++
+	if !w.writeDownstream([]byte("data: ")) {
+		return false
+	}
+	if !w.writeDownstream(body) {
+		return false
+	}
+	if !w.writeDownstream([]byte("\n\n")) {
+		return false
+	}
 	w.Flush()
+	return w.downstreamErr == nil
 }
 
-func (w *compatGeminiStreamWriter) emitDone() {
+func (w *compatGeminiStreamWriter) emitDone(synthetic bool) bool {
 	if w.doneSent {
-		return
+		return w.downstreamErr == nil
 	}
 	w.ensureSuccessHeaders()
-	_, _ = w.dst.Write([]byte("data: [DONE]\n\n"))
+	w.syntheticDone = synthetic
+	if !w.writeDownstream([]byte("data: [DONE]\n\n")) {
+		return false
+	}
 	w.Flush()
 	w.doneSent = true
+	return w.downstreamErr == nil
 }
 
 func (w *compatGeminiStreamWriter) finalize() {
+	if w.downstreamErr != nil {
+		return
+	}
 	if w.status != 0 && w.status != http.StatusOK {
 		writeCompatOpenAIUpstreamError(w.dst, w.status, compatExtractErrorBody(w.rawErrorBody.Bytes()))
 		return
@@ -403,8 +510,49 @@ func (w *compatGeminiStreamWriter) finalize() {
 		line := strings.TrimRight(w.lineBuf.String(), "\r\n")
 		w.lineBuf.Reset()
 		if line != "" {
-			w.handleGeminiStreamLine(line)
+			if !w.handleGeminiStreamLine(line) {
+				return
+			}
 		}
 	}
-	w.emitDone()
+	_ = w.emitDone(!w.terminalSignalSeen)
+}
+
+func (w *compatGeminiStreamWriter) writeDownstream(p []byte) bool {
+	n, err := w.dst.Write(p)
+	w.downstreamBytes += n
+	if err != nil && w.downstreamErr == nil {
+		w.downstreamErr = err
+	}
+	return err == nil
+}
+
+func (w *compatGeminiStreamWriter) completed() bool {
+	return (w.status == 0 || w.status == http.StatusOK) && w.downstreamErr == nil && w.terminalSignalSeen && w.doneSent
+}
+
+func (w *compatGeminiStreamWriter) ClientResponseObservation() map[string]any {
+	meta := map[string]any{
+		"http_status":          w.statusOrOK(),
+		"headers_written":      w.headersWritten,
+		"chunks_emitted":       w.chunksEmitted,
+		"content_chunks":       w.contentChunks,
+		"role_sent":            w.roleSent,
+		"done_sent":            w.doneSent,
+		"terminal_signal_seen": w.terminalSignalSeen,
+		"synthetic_done":       w.syntheticDone,
+		"downstream_bytes":     w.downstreamBytes,
+		"delivery_completed":   w.completed(),
+	}
+	if w.downstreamErr != nil {
+		meta["downstream_error"] = w.downstreamErr.Error()
+	}
+	return meta
+}
+
+func (w *compatGeminiStreamWriter) statusOrOK() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
 }

--- a/internal/server/compat_openai_types.go
+++ b/internal/server/compat_openai_types.go
@@ -204,6 +204,8 @@ type compatTarget struct {
 type compatStreamWriter interface {
 	http.ResponseWriter
 	finalize()
+	completed() bool
+	ClientResponseObservation() map[string]any
 }
 
 type compatResponseCapture struct {

--- a/internal/server/server_runtime.go
+++ b/internal/server/server_runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yansircc/llm-broker/internal/domain"
 	"github.com/yansircc/llm-broker/internal/driver"
 	"github.com/yansircc/llm-broker/internal/neterr"
+	"github.com/yansircc/llm-broker/internal/requestid"
 )
 
 // Run starts the server and blocks until shutdown.
@@ -156,6 +157,7 @@ func (s *Server) runLeaderBackgroundJobs(ctx context.Context) {
 
 func (s *Server) requestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = requestid.Ensure(r, w)
 		reqID := s.requestSeq.Add(1)
 		s.activeRequests.Store(reqID, activeRequest{
 			ID:        reqID,


### PR DESCRIPTION
## Summary
- add end-to-end broker request ids and compat lifecycle logging
- record local driver validation failures and stream completion state in request logs
- harden compat stream delivery observability and client response metadata
- normalize a safe set of compat Claude model aliases while keeping native validation strict
- fix driver JSON error encoding so quoted model names return valid JSON

## Why
Recent compat debugging showed three different failure classes were getting mixed together:
- request-side bad model names rejected locally before upstream
- compat requests translated successfully but failing upstream with 404 model errors
- stream responses that looked like HTTP 200 but did not complete cleanly downstream

This PR makes those paths distinguishable in request logs and activity data, and adds a narrow compat-only alias normalization layer for common low-grade Claude model naming mistakes.

## Testing
- go test ./...
