### PR TITLE
feat: capacity-aware route binding rebalance

### DIFF
--- a/internal/pool/pool_schedule.go
+++ b/internal/pool/pool_schedule.go
@@ -104,6 +104,64 @@ func (p *Pool) IsAvailableForSurface(accountID string, drv driver.SchedulerDrive
 	return p.isAvailable(acct, drv, model, time.Now())
 }
 
+// rebalanceGap is the minimum priority difference that triggers rebinding
+// to a better alternative. A value of 30 means: only rebalance when the best
+// alternative has ≥30 more remaining-capacity points than the current account.
+const rebalanceGap = 30
+
+// ShouldKeepRouteBinding returns true if the sticky route binding should be
+// honoured. It returns false if the account is unavailable OR a significantly
+// better alternative exists (priority gap > rebalanceGap).
+// Manual-priority accounts always stick — rebalance only applies to auto mode.
+func (p *Pool) ShouldKeepRouteBinding(accountID string, drv driver.SchedulerDriver, model string, surface domain.Surface) bool {
+	if !p.IsAvailableForSurface(accountID, drv, model, surface) {
+		return false
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	acct, ok := p.accounts[accountID]
+	if !ok {
+		return false
+	}
+	if acct.PriorityMode != "auto" {
+		return true
+	}
+	currentPri := p.accountPriorityLocked(acct, drv)
+	bestPri := p.bestAvailablePriorityLocked(drv, model, surface, accountID)
+	return bestPri-currentPri <= rebalanceGap
+}
+
+func (p *Pool) accountPriorityLocked(acct *domain.Account, drv driver.SchedulerDriver) int {
+	if acct.PriorityMode == "auto" {
+		return drv.AutoPriority(json.RawMessage(p.bucketStateLocked(acct)))
+	}
+	return acct.Priority
+}
+
+func (p *Pool) bestAvailablePriorityLocked(drv driver.SchedulerDriver, model string, surface domain.Surface, excludeAccountID string) int {
+	now := time.Now()
+	best := 0
+	for _, acct := range p.accounts {
+		if acct.ID == excludeAccountID {
+			continue
+		}
+		if acct.Provider != drv.Provider() {
+			continue
+		}
+		if !p.allowedOnSurfaceLocked(acct, surface) {
+			continue
+		}
+		if !p.isAvailable(acct, drv, model, now) {
+			continue
+		}
+		pri := p.accountPriorityLocked(acct, drv)
+		if pri > best {
+			best = pri
+		}
+	}
+	return best
+}
+
 func (p *Pool) SurfaceAvailabilityMap() map[string]SurfaceAvailability {
 	if err := p.refreshState(context.Background()); err != nil {
 		slog.Warn("pool refresh failed", "op", "surface_availability_map", "error", err)
@@ -189,10 +247,7 @@ func (p *Pool) PickForSurface(drv driver.SchedulerDriver, exclusions []Exclusion
 			continue
 		}
 		bucket := buckets[bucketKey]
-		pri := acct.Priority
-		if acct.PriorityMode == "auto" {
-			pri = drv.AutoPriority(json.RawMessage(p.bucketStateLocked(acct)))
-		}
+		pri := p.accountPriorityLocked(acct, drv)
 		if bucket == nil {
 			bucket = &bucketCandidate{key: bucketKey, priority: pri}
 			buckets[bucketKey] = bucket

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1368,3 +1368,145 @@ func TestCleanup_SharedBucket_BlockedStaysBlocked(t *testing.T) {
 		t.Fatal("missing 'cooldown expired' event")
 	}
 }
+
+// priorityDriver is a mockDriver that computes AutoPriority from a "remaining"
+// field in the state JSON, mirroring the real Codex driver's behaviour.
+type priorityDriver struct {
+	mockDriver
+}
+
+func (d *priorityDriver) AutoPriority(state json.RawMessage) int {
+	var s struct {
+		Remaining int `json:"remaining"`
+	}
+	if json.Unmarshal(state, &s) != nil || s.Remaining == 0 {
+		return 50 // default for empty/unparseable state
+	}
+	return s.Remaining
+}
+
+func TestShouldKeepRouteBinding_RebalancesWhenBetterAlternative(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	// acctA: low remaining capacity (priority 10)
+	acctA := activeAccount("a", "a@x")
+	acctA.PriorityMode = "auto"
+	acctA.ProviderStateJSON = `{"remaining":10}`
+
+	// acctB: high remaining capacity (priority 90)
+	acctB := activeAccount("b", "b@x")
+	acctB.PriorityMode = "auto"
+	acctB.ProviderStateJSON = `{"remaining":90}`
+
+	p := newTestPool(t, acctA, acctB)
+
+	// Gap is 80 (90-10) > rebalanceGap(30) → should NOT keep binding to A
+	if p.ShouldKeepRouteBinding("a", drv, "", domain.SurfaceNative) {
+		t.Fatal("expected rebalance: gap 80 > 30, but binding was kept")
+	}
+}
+
+func TestShouldKeepRouteBinding_SticksWhenGapSmall(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	acctA := activeAccount("a", "a@x")
+	acctA.PriorityMode = "auto"
+	acctA.ProviderStateJSON = `{"remaining":60}`
+
+	acctB := activeAccount("b", "b@x")
+	acctB.PriorityMode = "auto"
+	acctB.ProviderStateJSON = `{"remaining":70}`
+
+	p := newTestPool(t, acctA, acctB)
+
+	// Gap is 10 (70-60) <= rebalanceGap(30) → should keep binding
+	if !p.ShouldKeepRouteBinding("a", drv, "", domain.SurfaceNative) {
+		t.Fatal("expected sticky: gap 10 <= 30, but binding was released")
+	}
+}
+
+func TestShouldKeepRouteBinding_UnavailableReturnsFalse(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	acctA := activeAccount("a", "a@x")
+	future := time.Now().Add(time.Hour)
+	acctA.CooldownUntil = &future
+
+	acctB := activeAccount("b", "b@x")
+
+	p := newTestPool(t, acctA, acctB)
+
+	// A is in cooldown → should not keep
+	if p.ShouldKeepRouteBinding("a", drv, "", domain.SurfaceNative) {
+		t.Fatal("expected false for unavailable account in cooldown")
+	}
+}
+
+func TestShouldKeepRouteBinding_NoAlternativeSticks(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	acctA := activeAccount("a", "a@x")
+	acctA.PriorityMode = "auto"
+	acctA.ProviderStateJSON = `{"remaining":5}`
+
+	p := newTestPool(t, acctA)
+
+	// Only account → bestPri=0, currentPri=5, gap=-5 ≤ 30 → stick
+	if !p.ShouldKeepRouteBinding("a", drv, "", domain.SurfaceNative) {
+		t.Fatal("expected sticky when no alternatives exist")
+	}
+}
+
+func TestBestAvailablePriorityLocked(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	acctA := activeAccount("a", "a@x")
+	acctA.PriorityMode = "auto"
+	acctA.ProviderStateJSON = `{"remaining":10}`
+
+	acctB := activeAccount("b", "b@x")
+	acctB.PriorityMode = "auto"
+	acctB.ProviderStateJSON = `{"remaining":90}`
+
+	acctC := activeAccount("c", "c@x")
+	acctC.PriorityMode = "auto"
+	acctC.ProviderStateJSON = `{"remaining":60}`
+
+	p := newTestPool(t, acctA, acctB, acctC)
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	// Best excluding A → B with 90
+	best := p.bestAvailablePriorityLocked(drv, "", domain.SurfaceNative, "a")
+	if best != 90 {
+		t.Fatalf("bestAvailablePriority excluding a = %d, want 90", best)
+	}
+
+	// Best excluding B → C with 60
+	best = p.bestAvailablePriorityLocked(drv, "", domain.SurfaceNative, "b")
+	if best != 60 {
+		t.Fatalf("bestAvailablePriority excluding b = %d, want 60", best)
+	}
+}
+
+func TestShouldKeepRouteBinding_ManualModeAlwaysSticks(t *testing.T) {
+	drv := &priorityDriver{mockDriver{provider: domain.ProviderClaude}}
+
+	// acctA: manual mode with low priority
+	acctA := activeAccount("a", "a@x")
+	acctA.PriorityMode = "manual"
+	acctA.Priority = 5
+
+	// acctB: auto mode with high remaining capacity
+	acctB := activeAccount("b", "b@x")
+	acctB.PriorityMode = "auto"
+	acctB.ProviderStateJSON = `{"remaining":95}`
+
+	p := newTestPool(t, acctA, acctB)
+
+	// Even though gap is huge, manual mode account always sticks
+	if !p.ShouldKeepRouteBinding("a", drv, "", domain.SurfaceNative) {
+		t.Fatal("expected manual-mode account to always stick, but binding was released")
+	}
+}

--- a/internal/relay/relay_request.go
+++ b/internal/relay/relay_request.go
@@ -149,7 +149,7 @@ func (r *Relay) resolveUserRouteAccount(ctx context.Context, drv driver.Executio
 	if !ok {
 		return ""
 	}
-	if r.pool.IsAvailableForSurface(accountID, drv, model, surface) {
+	if r.pool.ShouldKeepRouteBinding(accountID, drv, model, surface) {
 		return accountID
 	}
 	return ""

--- a/internal/server/admin_probe.go
+++ b/internal/server/admin_probe.go
@@ -32,6 +32,9 @@ func (s *Server) refreshStaleAccounts(ctx context.Context) {
 		if acct.Status != domain.StatusActive {
 			continue
 		}
+		if acct.CooldownUntil != nil && acct.CooldownUntil.Sub(now) > 30*time.Minute {
+			continue
+		}
 
 		drv, ok := s.adminDrivers[acct.Provider]
 		if !ok {


### PR DESCRIPTION
## Summary

- Route bindings were permanently sticky — new accounts (e.g. frankiexu32 with weight 100) got 0 requests while saturated accounts (shawnagray5788 at 97% secondary) got all 531
- Add `ShouldKeepRouteBinding` that compares remaining capacity: when the best alternative exceeds the bound account by >30 priority points, the binding is released for redistribution
- Manual-priority accounts always stick (not subject to auto-rebalance)
- Skip probing accounts with long cooldowns (>30min) to stop noise from exhausted accounts being probed every minute (tangchonglin 5.7d cooldown was generating a warn log every 60s)
- Short cooldowns (<30min, e.g. 429 pause) still allow probe-based early recovery

## Test plan

- [x] `TestShouldKeepRouteBinding_RebalancesWhenBetterAlternative` — large gap triggers rebalance
- [x] `TestShouldKeepRouteBinding_SticksWhenGapSmall` — small gap keeps binding
- [x] `TestShouldKeepRouteBinding_UnavailableReturnsFalse` — cooldown account releases
- [x] `TestShouldKeepRouteBinding_NoAlternativeSticks` — sole account always sticks
- [x] `TestShouldKeepRouteBinding_ManualModeAlwaysSticks` — manual priority never rebalances
- [x] `TestBestAvailablePriorityLocked` — correct best-priority computation with exclusion
- [x] All existing pool, relay, server tests pass