### PR TITLE
feat: per-model-family rate limits for Codex (standard/spark isolation)

### DIFF
--- a/internal/driver/codex.go
+++ b/internal/driver/codex.go
@@ -55,11 +55,11 @@ func (d *CodexDriver) BuildRequest(ctx context.Context, input *RelayInput, acct 
 	return req, nil
 }
 
-func (d *CodexDriver) Interpret(statusCode int, headers http.Header, body []byte, model string, _ json.RawMessage) Effect {
+func (d *CodexDriver) Interpret(statusCode int, headers http.Header, body []byte, model string, prevState json.RawMessage) Effect {
 	upstreamErrorType, upstreamErrorMessage := parseCodexErrorInfo(body)
 	switch statusCode {
 	case http.StatusOK:
-		state := d.captureHeaders(headers)
+		state := d.captureHeaders(headers, prevState)
 		return Effect{Kind: EffectSuccess, Scope: EffectScopeBucket, UpdatedState: state}
 
 	case 529:
@@ -73,7 +73,7 @@ func (d *CodexDriver) Interpret(statusCode int, headers http.Header, body []byte
 		}
 
 	case 429:
-		state := d.captureHeaders(headers)
+		state := d.captureHeaders(headers, prevState)
 
 		until := time.Now().Add(d.cfg.Pauses.Pause429)
 		if retryAfter := parseRetryAfter(headers.Get("Retry-After")); retryAfter > 0 {

--- a/internal/driver/codex_admin.go
+++ b/internal/driver/codex_admin.go
@@ -19,7 +19,7 @@ func (d *CodexDriver) Probe(ctx context.Context, acct *domain.Account, token str
 		return ProbeResult{}, fmt.Errorf("codex account missing subject")
 	}
 
-	body := `{"model":"gpt-5.1-codex","messages":[{"role":"user","content":"Reply with OK only."}],"stream":true}`
+	body := `{"model":"gpt-5.1-codex","instructions":"Reply with OK only.","input":[{"role":"user","content":"test"}],"stream":true,"store":false}`
 	req, err := http.NewRequestWithContext(ctx, "POST", d.cfg.APIURL, strings.NewReader(body))
 	if err != nil {
 		return ProbeResult{}, err
@@ -82,19 +82,30 @@ func (d *CodexDriver) AutoPriority(state json.RawMessage) int {
 	if json.Unmarshal(state, &s) != nil {
 		return 50
 	}
-	primaryRemain := 100.0
-	if s.PrimaryUtil > 0 {
-		primaryRemain = (1.0 - s.PrimaryUtil) * 100
+	// Return the best remaining capacity across all families.
+	best := 0
+	for _, prefix := range s.allFamilies() {
+		f := s.family(prefix)
+		primaryRemain := 100.0
+		if f.PrimaryUtil > 0 {
+			primaryRemain = (1.0 - f.PrimaryUtil) * 100
+		}
+		secondaryRemain := 100.0
+		if f.SecondaryUtil > 0 {
+			secondaryRemain = (1.0 - f.SecondaryUtil) * 100
+		}
+		worst := primaryRemain
+		if secondaryRemain < worst {
+			worst = secondaryRemain
+		}
+		if int(worst) > best {
+			best = int(worst)
+		}
 	}
-	secondaryRemain := 100.0
-	if s.SecondaryUtil > 0 {
-		secondaryRemain = (1.0 - s.SecondaryUtil) * 100
+	if best == 0 && len(s.allFamilies()) == 0 {
+		return 50
 	}
-	pri := primaryRemain
-	if secondaryRemain < pri {
-		pri = secondaryRemain
-	}
-	return int(pri)
+	return best
 }
 
 func (d *CodexDriver) IsStale(state json.RawMessage, now time.Time) bool {
@@ -103,10 +114,29 @@ func (d *CodexDriver) IsStale(state json.RawMessage, now time.Time) bool {
 		return false
 	}
 	nowUnix := now.Unix()
-	return (s.PrimaryReset > 0 && s.PrimaryReset < nowUnix) ||
-		(s.SecondaryReset > 0 && s.SecondaryReset < nowUnix) ||
-		(s.PrimaryUtil > 0 && s.PrimaryReset == 0) ||
-		(s.SecondaryUtil > 0 && s.SecondaryReset == 0)
+	for _, prefix := range s.allFamilies() {
+		f := s.family(prefix)
+		if (f.PrimaryReset > 0 && f.PrimaryReset < nowUnix) ||
+			(f.SecondaryReset > 0 && f.SecondaryReset < nowUnix) ||
+			(f.PrimaryUtil > 0 && f.PrimaryReset == 0) ||
+			(f.SecondaryUtil > 0 && f.SecondaryReset == 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// computeFamilyCooldown returns a cooldown time for a single family,
+// or zero if the family is not exhausted.
+func computeFamilyCooldown(f CodexFamilyLimits, nowUnix int64) int64 {
+	var cd int64
+	if f.PrimaryUtil >= 0.99 && f.PrimaryReset > nowUnix {
+		cd = f.PrimaryReset
+	}
+	if f.SecondaryUtil >= 0.99 && f.SecondaryReset > nowUnix && f.SecondaryReset > cd {
+		cd = f.SecondaryReset
+	}
+	return cd
 }
 
 func (d *CodexDriver) ComputeExhaustedCooldown(state json.RawMessage, now time.Time) time.Time {
@@ -114,16 +144,26 @@ func (d *CodexDriver) ComputeExhaustedCooldown(state json.RawMessage, now time.T
 	if json.Unmarshal(state, &s) != nil {
 		return time.Time{}
 	}
+	families := s.allFamilies()
+	if len(families) == 0 {
+		return time.Time{}
+	}
 	nowUnix := now.Unix()
-	var cooldownUntil int64
-	if s.PrimaryUtil >= 0.99 && s.PrimaryReset > nowUnix {
-		cooldownUntil = s.PrimaryReset
+
+	// Only set bucket-level cooldown if ALL families are exhausted.
+	var earliest int64
+	for _, prefix := range families {
+		f := s.family(prefix)
+		cd := computeFamilyCooldown(f, nowUnix)
+		if cd == 0 {
+			return time.Time{} // this family still has capacity
+		}
+		if earliest == 0 || cd < earliest {
+			earliest = cd
+		}
 	}
-	if s.SecondaryUtil >= 0.99 && s.SecondaryReset > nowUnix && s.SecondaryReset > cooldownUntil {
-		cooldownUntil = s.SecondaryReset
-	}
-	if cooldownUntil > 0 {
-		return time.Unix(cooldownUntil, 0).UTC()
+	if earliest > 0 {
+		return time.Unix(earliest, 0).UTC()
 	}
 	return time.Time{}
 }
@@ -159,24 +199,73 @@ func (d *CodexDriver) GetUtilization(state json.RawMessage) []UtilWindow {
 	if json.Unmarshal(state, &s) != nil {
 		return nil
 	}
+	families := s.allFamilies()
+	if len(families) == 0 {
+		return nil
+	}
+
+	// Single family: return flat windows as before.
+	if len(families) == 1 {
+		f := s.family(families[0])
+		var windows []UtilWindow
+		if f.PrimaryUtil > 0 || f.PrimaryReset > 0 {
+			windows = append(windows, UtilWindow{
+				Label: "primary", Pct: int(f.PrimaryUtil * 100), Reset: f.PrimaryReset, SubPct: -1,
+			})
+		}
+		if f.SecondaryUtil > 0 || f.SecondaryReset > 0 {
+			windows = append(windows, UtilWindow{
+				Label: "secondary", Pct: int(f.SecondaryUtil * 100), Reset: f.SecondaryReset, SubPct: -1,
+			})
+		}
+		return windows
+	}
+
+	// Multiple families: merge into primary/secondary with sub-family data.
+	// Standard ("") is the main value; first non-standard family is the sub.
+	std := s.family("")
+	var subPrefix string
+	for _, p := range families {
+		if p != "" {
+			subPrefix = p
+			break
+		}
+	}
+	sub := s.family(subPrefix)
+	subName := codexFamilyDisplayName(subPrefix, sub)
+	if subName == "" {
+		subName = "spark"
+	}
+
 	var windows []UtilWindow
-	if s.PrimaryUtil > 0 || s.PrimaryReset > 0 {
+	if std.PrimaryUtil > 0 || std.PrimaryReset > 0 || sub.PrimaryUtil > 0 || sub.PrimaryReset > 0 {
 		windows = append(windows, UtilWindow{
-			Label: "primary",
-			Pct:   int(s.PrimaryUtil * 100),
-			Reset: s.PrimaryReset,
+			Label: "primary", Pct: int(std.PrimaryUtil * 100), Reset: std.PrimaryReset,
+			SubLabel: subName, SubPct: int(sub.PrimaryUtil * 100), SubReset: sub.PrimaryReset,
 		})
 	}
-	if s.SecondaryUtil > 0 || s.SecondaryReset > 0 {
+	if std.SecondaryUtil > 0 || std.SecondaryReset > 0 || sub.SecondaryUtil > 0 || sub.SecondaryReset > 0 {
 		windows = append(windows, UtilWindow{
-			Label: "secondary",
-			Pct:   int(s.SecondaryUtil * 100),
-			Reset: s.SecondaryReset,
+			Label: "secondary", Pct: int(std.SecondaryUtil * 100), Reset: std.SecondaryReset,
+			SubLabel: subName, SubPct: int(sub.SecondaryUtil * 100), SubReset: sub.SecondaryReset,
 		})
 	}
 	return windows
 }
 
-func (d *CodexDriver) CanServe(_ json.RawMessage, _ string, _ time.Time) bool {
+func (d *CodexDriver) CanServe(state json.RawMessage, model string, now time.Time) bool {
+	var s CodexState
+	if json.Unmarshal(state, &s) != nil {
+		return true
+	}
+	family := codexModelFamily(model)
+	f := s.family(family)
+	nowUnix := now.Unix()
+	if f.PrimaryUtil >= 0.99 && f.PrimaryReset > nowUnix {
+		return false
+	}
+	if f.SecondaryUtil >= 0.99 && f.SecondaryReset > nowUnix {
+		return false
+	}
 	return true
 }

--- a/internal/driver/codex_descriptor.go
+++ b/internal/driver/codex_descriptor.go
@@ -43,11 +43,18 @@ func (d *CodexDriver) Info() ProviderInfo {
 func (d *CodexDriver) Models() []Model {
 	return []Model{
 		{ID: "gpt-5.4", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 1050000},
+		{ID: "gpt-5.4-mini", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 1050000},
 		{ID: "gpt-5.3-codex", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
+		{ID: "gpt-5.3-codex-spark", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 128000},
 		{ID: "gpt-5.2-codex", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
+		{ID: "gpt-5.2", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
 		{ID: "gpt-5.1-codex-max", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
 		{ID: "gpt-5.1-codex", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
 		{ID: "gpt-5.1-codex-mini", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
+		{ID: "gpt-5.1", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
+		{ID: "gpt-5-codex", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 192000},
+		{ID: "gpt-5-codex-mini", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 192000},
+		{ID: "gpt-5", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 192000},
 		{ID: "codex-1", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 192000},
 	}
 }

--- a/internal/driver/codex_support.go
+++ b/internal/driver/codex_support.go
@@ -3,45 +3,189 @@ package driver
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
-// CodexState holds the provider-specific rate-limit state for Codex accounts.
-type CodexState struct {
-	PrimaryUtil    float64 `json:"primary_util"`
-	PrimaryReset   int64   `json:"primary_reset"`
-	SecondaryUtil  float64 `json:"secondary_util"`
-	SecondaryReset int64   `json:"secondary_reset"`
+// CodexFamilyLimits holds rate-limit state for one quota family.
+type CodexFamilyLimits struct {
+	PrimaryUtil    float64 `json:"pu"`
+	PrimaryReset   int64   `json:"pr"`
+	SecondaryUtil  float64 `json:"su"`
+	SecondaryReset int64   `json:"sr"`
+	LimitName      string  `json:"name,omitempty"` // e.g. "GPT-5.3-Codex-Spark"
 }
 
-func (d *CodexDriver) captureHeaders(headers http.Header) json.RawMessage {
+// CodexState holds the provider-specific rate-limit state for Codex accounts.
+// State is stored per quota family: "" = standard codex, "bengalfox" = spark, etc.
+type CodexState struct {
+	Families map[string]CodexFamilyLimits `json:"families,omitempty"`
+
+	// Legacy flat fields — read for backward compat, cleared on first write.
+	PrimaryUtil    float64 `json:"primary_util,omitempty"`
+	PrimaryReset   int64   `json:"primary_reset,omitempty"`
+	SecondaryUtil  float64 `json:"secondary_util,omitempty"`
+	SecondaryReset int64   `json:"secondary_reset,omitempty"`
+}
+
+// family returns the limits for the given family prefix.
+// Falls back to legacy flat fields for the standard ("") family.
+func (s *CodexState) family(prefix string) CodexFamilyLimits {
+	if s.Families != nil {
+		if f, ok := s.Families[prefix]; ok {
+			return f
+		}
+	}
+	if prefix == "" && (s.PrimaryUtil > 0 || s.PrimaryReset > 0 || s.SecondaryUtil > 0 || s.SecondaryReset > 0) {
+		return CodexFamilyLimits{
+			PrimaryUtil: s.PrimaryUtil, PrimaryReset: s.PrimaryReset,
+			SecondaryUtil: s.SecondaryUtil, SecondaryReset: s.SecondaryReset,
+		}
+	}
+	return CodexFamilyLimits{}
+}
+
+// allFamilies returns all known family prefixes in stable order.
+func (s *CodexState) allFamilies() []string {
+	if len(s.Families) > 0 {
+		keys := make([]string, 0, len(s.Families))
+		for k := range s.Families {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+	if s.PrimaryUtil > 0 || s.PrimaryReset > 0 || s.SecondaryUtil > 0 || s.SecondaryReset > 0 {
+		return []string{""}
+	}
+	return nil
+}
+
+// codexModelFamily maps a model name to its quota family prefix.
+func codexModelFamily(model string) string {
+	if strings.Contains(strings.ToLower(model), "spark") {
+		return "bengalfox"
+	}
+	return ""
+}
+
+// codexFamilyDisplayName returns a human-readable label prefix for a family.
+func codexFamilyDisplayName(prefix string, f CodexFamilyLimits) string {
+	if f.LimitName != "" {
+		return f.LimitName
+	}
+	if prefix == "" {
+		return ""
+	}
+	return prefix
+}
+
+func (d *CodexDriver) captureHeaders(headers http.Header, prevState json.RawMessage) json.RawMessage {
 	if headers == nil {
+		if len(prevState) > 0 {
+			return prevState
+		}
 		return nil
 	}
-	var s CodexState
-	if v := headers.Get("x-codex-primary-used-percent"); v != "" {
-		if pct, err := strconv.ParseFloat(v, 64); err == nil {
-			s.PrimaryUtil = pct / 100
-		}
+
+	var state CodexState
+	if len(prevState) > 0 {
+		json.Unmarshal(prevState, &state)
 	}
-	if v := headers.Get("x-codex-primary-reset-after-seconds"); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil {
-			s.PrimaryReset = time.Now().Unix() + int64(secs)
-		}
+
+	// Migrate legacy flat fields into Families map.
+	if state.Families == nil {
+		state.Families = make(map[string]CodexFamilyLimits)
 	}
-	if v := headers.Get("x-codex-secondary-used-percent"); v != "" {
-		if pct, err := strconv.ParseFloat(v, 64); err == nil {
-			s.SecondaryUtil = pct / 100
+	if state.PrimaryUtil > 0 || state.PrimaryReset > 0 || state.SecondaryUtil > 0 || state.SecondaryReset > 0 {
+		if _, ok := state.Families[""]; !ok {
+			state.Families[""] = CodexFamilyLimits{
+				PrimaryUtil: state.PrimaryUtil, PrimaryReset: state.PrimaryReset,
+				SecondaryUtil: state.SecondaryUtil, SecondaryReset: state.SecondaryReset,
+			}
 		}
+		state.PrimaryUtil = 0
+		state.PrimaryReset = 0
+		state.SecondaryUtil = 0
+		state.SecondaryReset = 0
 	}
-	if v := headers.Get("x-codex-secondary-reset-after-seconds"); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil {
-			s.SecondaryReset = time.Now().Unix() + int64(secs)
+
+	// Discover family prefixes from headers.
+	// Standard: x-codex-primary-used-percent
+	// Extra:    x-codex-{family}-primary-used-percent
+	prefixes := discoverCodexFamilyPrefixes(headers)
+	now := time.Now().Unix()
+	for _, prefix := range prefixes {
+		f := parseCodexFamilyHeaders(headers, prefix, now)
+		// Capture limit-name if available.
+		if prefix != "" {
+			if name := headers.Get("x-codex-" + prefix + "-limit-name"); name != "" {
+				f.LimitName = name
+			}
 		}
+		state.Families[prefix] = f
 	}
-	data, _ := json.Marshal(s)
+
+	data, _ := json.Marshal(state)
 	return data
+}
+
+// discoverCodexFamilyPrefixes finds all quota-family prefixes in the response headers.
+// Returns "" for the standard family and e.g. "bengalfox" for spark.
+func discoverCodexFamilyPrefixes(headers http.Header) []string {
+	seen := map[string]bool{}
+	for key := range headers {
+		lower := strings.ToLower(key)
+		if !strings.HasPrefix(lower, "x-codex-") {
+			continue
+		}
+		rest := lower[len("x-codex-"):]
+		if rest == "primary-used-percent" || rest == "secondary-used-percent" {
+			seen[""] = true
+		} else if idx := strings.Index(rest, "-primary-used-percent"); idx > 0 {
+			seen[rest[:idx]] = true
+		} else if idx := strings.Index(rest, "-secondary-used-percent"); idx > 0 {
+			seen[rest[:idx]] = true
+		}
+	}
+	prefixes := make([]string, 0, len(seen))
+	for p := range seen {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+	return prefixes
+}
+
+// parseCodexFamilyHeaders extracts primary/secondary limits for a specific family prefix.
+func parseCodexFamilyHeaders(headers http.Header, prefix string, nowUnix int64) CodexFamilyLimits {
+	hp := "x-codex-"
+	if prefix != "" {
+		hp = "x-codex-" + prefix + "-"
+	}
+	var f CodexFamilyLimits
+	if v := headers.Get(hp + "primary-used-percent"); v != "" {
+		if pct, err := strconv.ParseFloat(v, 64); err == nil {
+			f.PrimaryUtil = pct / 100
+		}
+	}
+	if v := headers.Get(hp + "primary-reset-after-seconds"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil {
+			f.PrimaryReset = nowUnix + int64(secs)
+		}
+	}
+	if v := headers.Get(hp + "secondary-used-percent"); v != "" {
+		if pct, err := strconv.ParseFloat(v, 64); err == nil {
+			f.SecondaryUtil = pct / 100
+		}
+	}
+	if v := headers.Get(hp + "secondary-reset-after-seconds"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil {
+			f.SecondaryReset = nowUnix + int64(secs)
+		}
+	}
+	return f
 }
 
 type codexUsageFields struct {

--- a/internal/driver/codex_test.go
+++ b/internal/driver/codex_test.go
@@ -2,10 +2,12 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/yansircc/llm-broker/internal/domain"
 )
@@ -53,5 +55,283 @@ func TestCodexProbeRequiresSubject(t *testing.T) {
 	_, err := d.Probe(context.Background(), acct, "tok", client)
 	if err == nil {
 		t.Fatal("Probe() error = nil, want missing subject error")
+	}
+}
+
+// --- Per-family rate limit tests ---
+
+func multiFamilyHeaders() http.Header {
+	h := make(http.Header)
+	// Standard codex family
+	h.Set("x-codex-primary-used-percent", "62")
+	h.Set("x-codex-primary-reset-after-seconds", "7200")
+	h.Set("x-codex-secondary-used-percent", "99")
+	h.Set("x-codex-secondary-reset-after-seconds", "129000")
+	// Spark (bengalfox) family
+	h.Set("x-codex-bengalfox-primary-used-percent", "0")
+	h.Set("x-codex-bengalfox-primary-reset-after-seconds", "18000")
+	h.Set("x-codex-bengalfox-secondary-used-percent", "1")
+	h.Set("x-codex-bengalfox-secondary-reset-after-seconds", "604000")
+	h.Set("x-codex-bengalfox-limit-name", "GPT-5.3-Codex-Spark")
+	return h
+}
+
+func TestCaptureHeaders_MultiFamilyParsing(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	state := d.captureHeaders(multiFamilyHeaders(), nil)
+
+	var s CodexState
+	if err := json.Unmarshal(state, &s); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if len(s.Families) != 2 {
+		t.Fatalf("Families count = %d, want 2", len(s.Families))
+	}
+
+	std := s.family("")
+	if std.PrimaryUtil != 0.62 {
+		t.Errorf("standard PrimaryUtil = %v, want 0.62", std.PrimaryUtil)
+	}
+	if std.SecondaryUtil != 0.99 {
+		t.Errorf("standard SecondaryUtil = %v, want 0.99", std.SecondaryUtil)
+	}
+
+	spark := s.family("bengalfox")
+	if spark.PrimaryUtil != 0 {
+		t.Errorf("spark PrimaryUtil = %v, want 0", spark.PrimaryUtil)
+	}
+	if spark.SecondaryUtil != 0.01 {
+		t.Errorf("spark SecondaryUtil = %v, want 0.01", spark.SecondaryUtil)
+	}
+	if spark.LimitName != "GPT-5.3-Codex-Spark" {
+		t.Errorf("spark LimitName = %q, want GPT-5.3-Codex-Spark", spark.LimitName)
+	}
+}
+
+func TestCaptureHeaders_LegacyMigration(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	legacy := `{"primary_util":0.5,"primary_reset":9999999999,"secondary_util":0.8,"secondary_reset":9999999999}`
+
+	// New headers arrive (only standard family)
+	h := make(http.Header)
+	h.Set("x-codex-primary-used-percent", "60")
+	h.Set("x-codex-primary-reset-after-seconds", "3600")
+	h.Set("x-codex-secondary-used-percent", "85")
+	h.Set("x-codex-secondary-reset-after-seconds", "86400")
+
+	state := d.captureHeaders(h, json.RawMessage(legacy))
+	var s CodexState
+	json.Unmarshal(state, &s)
+
+	// Legacy flat fields should be zeroed
+	if s.PrimaryUtil != 0 || s.SecondaryUtil != 0 {
+		t.Fatalf("legacy flat fields not zeroed: primary=%v secondary=%v", s.PrimaryUtil, s.SecondaryUtil)
+	}
+
+	// New values should be in Families[""]
+	std := s.family("")
+	if std.PrimaryUtil != 0.6 {
+		t.Errorf("migrated PrimaryUtil = %v, want 0.6", std.PrimaryUtil)
+	}
+	if std.SecondaryUtil != 0.85 {
+		t.Errorf("migrated SecondaryUtil = %v, want 0.85", std.SecondaryUtil)
+	}
+}
+
+func TestCanServe_PerFamily(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	now := time.Now()
+	futureReset := now.Add(1 * time.Hour).Unix()
+
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"":          {SecondaryUtil: 0.99, SecondaryReset: futureReset}, // standard exhausted
+			"bengalfox": {SecondaryUtil: 0.01, SecondaryReset: futureReset}, // spark available
+		},
+	})
+
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5.3-codex", false},       // standard family exhausted
+		{"gpt-5.4", false},             // standard family
+		{"gpt-5.3-codex-spark", true},  // spark family has capacity
+		{"codex-1", false},             // standard family
+	}
+	for _, tt := range tests {
+		if got := d.CanServe(state, tt.model, now); got != tt.want {
+			t.Errorf("CanServe(%q) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestCanServe_ExpiredResetAllows(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	now := time.Now()
+	pastReset := now.Add(-1 * time.Hour).Unix()
+
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"": {SecondaryUtil: 0.99, SecondaryReset: pastReset},
+		},
+	})
+
+	if !d.CanServe(state, "gpt-5.3-codex", now) {
+		t.Error("CanServe should return true when reset time has passed")
+	}
+}
+
+func TestComputeExhaustedCooldown_PartialExhaustion(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	now := time.Now()
+	futureReset := now.Add(2 * time.Hour).Unix()
+
+	// Standard exhausted, spark has capacity — no bucket cooldown
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"":          {SecondaryUtil: 0.99, SecondaryReset: futureReset},
+			"bengalfox": {SecondaryUtil: 0.01, SecondaryReset: futureReset},
+		},
+	})
+	cd := d.ComputeExhaustedCooldown(state, now)
+	if !cd.IsZero() {
+		t.Errorf("expected no cooldown when spark has capacity, got %v", cd)
+	}
+}
+
+func TestComputeExhaustedCooldown_AllExhausted(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	now := time.Now()
+	stdReset := now.Add(2 * time.Hour).Unix()
+	sparkReset := now.Add(6 * time.Hour).Unix()
+
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"":          {SecondaryUtil: 0.99, SecondaryReset: stdReset},
+			"bengalfox": {SecondaryUtil: 0.99, SecondaryReset: sparkReset},
+		},
+	})
+	cd := d.ComputeExhaustedCooldown(state, now)
+	if cd.IsZero() {
+		t.Fatal("expected cooldown when all families exhausted")
+	}
+	// Should use earliest reset (standard @ 2h)
+	if cd.Unix() != stdReset {
+		t.Errorf("cooldown = %v, want earliest reset %v", cd.Unix(), stdReset)
+	}
+}
+
+func TestAutoPriority_BestFamily(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"":          {SecondaryUtil: 0.99}, // 1% remaining
+			"bengalfox": {SecondaryUtil: 0.01}, // 99% remaining
+		},
+	})
+	pri := d.AutoPriority(state)
+	if pri != 99 {
+		t.Errorf("AutoPriority = %d, want 99 (best family capacity)", pri)
+	}
+}
+
+func TestIsStale_PerFamily(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	now := time.Now()
+
+	// Standard has expired reset, spark is fine
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"":          {PrimaryUtil: 0.5, PrimaryReset: now.Add(-1 * time.Hour).Unix()},
+			"bengalfox": {PrimaryUtil: 0.1, PrimaryReset: now.Add(1 * time.Hour).Unix()},
+		},
+	})
+	if !d.IsStale(state, now) {
+		t.Error("IsStale should return true when any family has expired reset")
+	}
+}
+
+func TestGetUtilization_PerFamily(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	futureReset := time.Now().Add(1 * time.Hour).Unix()
+
+	state, _ := json.Marshal(CodexState{
+		Families: map[string]CodexFamilyLimits{
+			"": {
+				PrimaryUtil: 0.42, PrimaryReset: futureReset,
+				SecondaryUtil: 0.99, SecondaryReset: futureReset,
+			},
+			"bengalfox": {
+				PrimaryUtil: 0, PrimaryReset: futureReset,
+				SecondaryUtil: 0.01, SecondaryReset: futureReset,
+				LimitName: "GPT-5.3-Codex-Spark",
+			},
+		},
+	})
+	windows := d.GetUtilization(state)
+	if len(windows) != 2 {
+		t.Fatalf("GetUtilization returned %d windows, want 2 (merged)", len(windows))
+	}
+	// Primary window: standard 42%, spark 0%
+	if windows[0].Label != "primary" {
+		t.Errorf("windows[0].Label = %q, want 'primary'", windows[0].Label)
+	}
+	if windows[0].Pct != 42 {
+		t.Errorf("windows[0].Pct = %d, want 42", windows[0].Pct)
+	}
+	if windows[0].SubPct != 0 {
+		t.Errorf("windows[0].SubPct = %d, want 0", windows[0].SubPct)
+	}
+	if windows[0].SubLabel != "GPT-5.3-Codex-Spark" {
+		t.Errorf("windows[0].SubLabel = %q, want 'GPT-5.3-Codex-Spark'", windows[0].SubLabel)
+	}
+	// Secondary window: standard 99%, spark 1%
+	if windows[1].Pct != 99 {
+		t.Errorf("windows[1].Pct = %d, want 99", windows[1].Pct)
+	}
+	if windows[1].SubPct != 1 {
+		t.Errorf("windows[1].SubPct = %d, want 1", windows[1].SubPct)
+	}
+}
+
+func TestCodexModelFamily(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"gpt-5.3-codex", ""},
+		{"gpt-5.4", ""},
+		{"gpt-5.3-codex-spark", "bengalfox"},
+		{"GPT-5.3-Codex-Spark", "bengalfox"},
+		{"codex-1", ""},
+		{"gpt-5.1-codex-mini", ""},
+	}
+	for _, tt := range tests {
+		if got := codexModelFamily(tt.model); got != tt.want {
+			t.Errorf("codexModelFamily(%q) = %q, want %q", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestDiscoverCodexFamilyPrefixes(t *testing.T) {
+	h := multiFamilyHeaders()
+	prefixes := discoverCodexFamilyPrefixes(h)
+	if len(prefixes) != 2 {
+		t.Fatalf("found %d prefixes, want 2", len(prefixes))
+	}
+	// Should contain "" and "bengalfox"
+	foundStd, foundSpark := false, false
+	for _, p := range prefixes {
+		if p == "" {
+			foundStd = true
+		}
+		if p == "bengalfox" {
+			foundSpark = true
+		}
+	}
+	if !foundStd || !foundSpark {
+		t.Errorf("prefixes = %v, want [\"\", \"bengalfox\"]", prefixes)
 	}
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -105,9 +105,12 @@ type OAuthSession struct {
 
 // UtilWindow represents a rate-limit utilization window.
 type UtilWindow struct {
-	Label string // provider-defined display label
-	Pct   int    // 0-100
-	Reset int64  // unix seconds
+	Label    string // provider-defined display label
+	Pct      int    // 0-100
+	Reset    int64  // unix seconds
+	SubLabel string // optional: second family name (e.g. "spark")
+	SubPct   int    // optional: second family pct (-1 = absent)
+	SubReset int64  // optional: second family reset
 }
 
 type AccountField struct {

--- a/internal/server/account_view.go
+++ b/internal/server/account_view.go
@@ -47,11 +47,17 @@ func toWindowResponses(windows []driver.UtilWindow) []UtilizationWindowResponse 
 	}
 	resp := make([]UtilizationWindowResponse, 0, len(windows))
 	for _, window := range windows {
-		resp = append(resp, UtilizationWindowResponse{
+		w := UtilizationWindowResponse{
 			Label: window.Label,
 			Pct:   window.Pct,
 			Reset: window.Reset,
-		})
+		}
+		if window.SubPct >= 0 {
+			w.SubLabel = window.SubLabel
+			w.SubPct = &window.SubPct
+			w.SubReset = window.SubReset
+		}
+		resp = append(resp, w)
 	}
 	return resp
 }

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -28,9 +28,12 @@ type HealthInfo struct {
 }
 
 type UtilizationWindowResponse struct {
-	Label string `json:"label"`
-	Pct   int    `json:"pct"`
-	Reset int64  `json:"reset,omitempty"`
+	Label    string `json:"label"`
+	Pct      int    `json:"pct"`
+	Reset    int64  `json:"reset,omitempty"`
+	SubLabel string `json:"sub_label,omitempty"`
+	SubPct   *int   `json:"sub_pct,omitempty"`
+	SubReset int64  `json:"sub_reset,omitempty"`
 }
 
 type AccountFieldResponse struct {

--- a/web/src/lib/admin-types.ts
+++ b/web/src/lib/admin-types.ts
@@ -13,6 +13,9 @@ export interface UtilWindow {
 	label: string;
 	pct: number;
 	reset?: number;
+	sub_label?: string;
+	sub_pct?: number;
+	sub_reset?: number;
 }
 
 export interface HealthInfo {

--- a/web/src/routes/accounts/+page.svelte
+++ b/web/src/routes/accounts/+page.svelte
@@ -214,7 +214,11 @@
 			}
 			group.accounts.push(account);
 			account.windows.forEach((window, index) => {
-				if (!group!.window_labels[index]) group!.window_labels[index] = window.label;
+				if (!group!.window_labels[index]) {
+					let lbl = window.label;
+					if (window.sub_label) lbl += ` codex/spark`;
+					group!.window_labels[index] = lbl;
+				}
 			});
 		}
 		return [...groups.values()].sort((a, b) => a.provider.localeCompare(b.provider));
@@ -342,7 +346,7 @@
 											<span class="muted">&ndash;</span>
 										{:else if window}
 											{@const remain = 100 - window.pct}
-											<span class={remainClass(remain)}>{remain}%</span> <span class="muted">{remainTime(window.reset ?? null)}</span>
+											<span class={remainClass(remain)}>{remain}%</span>{#if window.sub_pct != null}{@const subRemain = 100 - window.sub_pct}/<span class={remainClass(subRemain)}>{subRemain}%</span>{/if} <span class="muted">{remainTime(window.reset ?? null)}</span>
 										{:else}
 											<span class="muted">&ndash;</span>
 										{/if}


### PR DESCRIPTION
## Summary
- OpenAI Codex returns separate rate-limit headers per quota family (standard vs spark/bengalfox). Previously the broker stored a flat state, so exhausting standard weekly quota blocked spark too — even with 99% spark capacity remaining.
- `CodexState` now stores per-family limits; `CanServe` gates per-model-family; bucket cooldown only triggers when ALL families are exhausted.
- Dashboard shows combined `codex/spark` columns (e.g. `1%/100%`). Model catalog updated with all official models including `gpt-5.3-codex-spark`.

## Test plan
- [x] 13 new unit tests covering multi-family parsing, CanServe per-family gating, exhaustion cooldown, legacy migration
- [x] All existing tests pass (`go test ./...`)
- [x] Verified on ccc.210k.cc: `gpt-5.3-codex` → 503 (standard exhausted), `gpt-5.3-codex-spark` → 200 OK
- [x] Dashboard shows per-family utilization in merged columns