### PR TITLE
Hotfix Claude compat scheduling for legacy-direct accounts

### DIFF
--- a/cmd/local-cell-watchdog/main.go
+++ b/cmd/local-cell-watchdog/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/yansircc/llm-broker/internal/localcellwatchdog"
+)
+
+const (
+	defaultEnvFile = "/etc/llm-broker.env"
+	defaultIface   = "eth0"
+	requestTimeout = 15 * time.Second
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cfg, err := loadConfig(ctx)
+	if err != nil {
+		logger.Error("local cell watchdog config failed", "error", err)
+		os.Exit(1)
+	}
+
+	client := &adminClient{
+		baseURL: cfg.baseURL,
+		token:   cfg.token,
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+	runner := &osRunner{}
+	watchdog := localcellwatchdog.New(localcellwatchdog.Options{
+		Iface:  cfg.iface,
+		Client: client,
+		Runner: runner,
+		Logger: logger,
+	})
+
+	if err := watchdog.RunOnce(ctx); err != nil {
+		logger.Error("local cell watchdog run failed", "error", err)
+		os.Exit(1)
+	}
+	logger.Info("local cell watchdog run complete", "base_url", cfg.baseURL, "iface", cfg.iface)
+}
+
+type config struct {
+	baseURL string
+	token   string
+	iface   string
+}
+
+func loadConfig(ctx context.Context) (config, error) {
+	envFile := envOr("BROKER_ENV_FILE", defaultEnvFile)
+	token := strings.TrimSpace(os.Getenv("BROKER_API_TOKEN"))
+	if token == "" {
+		value, err := envFileValue(envFile, "API_TOKEN")
+		if err != nil {
+			return config{}, err
+		}
+		token = value
+	}
+	if token == "" {
+		return config{}, errors.New("missing broker API token")
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv("BROKER_URL"))
+	if baseURL == "" {
+		detected, err := detectBrokerBaseURL(ctx, token)
+		if err != nil {
+			return config{}, err
+		}
+		baseURL = detected
+	}
+
+	return config{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		iface:   envOr("WATCHDOG_IFACE", defaultIface),
+	}, nil
+}
+
+func detectBrokerBaseURL(ctx context.Context, token string) (string, error) {
+	candidates := []string{
+		"http://127.0.0.1:3002",
+		"http://127.0.0.1:3001",
+		"http://127.0.0.1:3000",
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	for _, baseURL := range candidates {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/admin/health", nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("x-api-key", token)
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return baseURL, nil
+		}
+	}
+	return "", errors.New("failed to detect broker admin base URL")
+}
+
+func envFileValue(path, key string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+		}
+	}
+	return "", fmt.Errorf("%s not found in %s", key, path)
+}
+
+func envOr(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+type adminClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func (c *adminClient) ListCells(ctx context.Context) ([]localcellwatchdog.Cell, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/admin/egress/cells", nil)
+	if err != nil {
+		return nil, err
+	}
+	var cells []localcellwatchdog.Cell
+	if err := c.doJSON(req, &cells); err != nil {
+		return nil, err
+	}
+	return cells, nil
+}
+
+func (c *adminClient) TestCell(ctx context.Context, cellID string) (localcellwatchdog.ProbeResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/admin/egress/cells/"+cellID+"/test", nil)
+	if err != nil {
+		return localcellwatchdog.ProbeResult{}, err
+	}
+	var result localcellwatchdog.ProbeResult
+	if err := c.doJSON(req, &result); err != nil {
+		return localcellwatchdog.ProbeResult{}, err
+	}
+	return result, nil
+}
+
+func (c *adminClient) ClearCooldown(ctx context.Context, cellID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/admin/egress/cells/"+cellID+"/clear-cooldown", nil)
+	if err != nil {
+		return err
+	}
+	return c.doJSON(req, nil)
+}
+
+func (c *adminClient) doJSON(req *http.Request, out any) error {
+	req.Header.Set("x-api-key", c.token)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("%s %s: http %d: %s", req.Method, req.URL.Path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+type osRunner struct{}
+
+func (r *osRunner) IPv6Present(ctx context.Context, iface, ipv6 string) (bool, error) {
+	output, err := exec.CommandContext(ctx, "ip", "-6", "addr", "show", "dev", iface).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("ip -6 addr show dev %s: %w: %s", iface, err, strings.TrimSpace(string(output)))
+	}
+	return strings.Contains(string(output), ipv6+"/"), nil
+}
+
+func (r *osRunner) AddIPv6(ctx context.Context, iface, ipv6 string) error {
+	output, err := exec.CommandContext(ctx, "ip", "-6", "addr", "add", ipv6+"/128", "dev", iface, "nodad").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ip -6 addr add %s/128 dev %s nodad: %w: %s", ipv6, iface, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func (r *osRunner) RestartService(ctx context.Context, service string) error {
+	output, err := exec.CommandContext(ctx, "systemctl", "restart", service).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("systemctl restart %s: %w: %s", service, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/docs/account-cell-lane-switching.md
+++ b/docs/account-cell-lane-switching.md
@@ -1,0 +1,106 @@
+# 账号 Surface 切换说明
+
+这件事切的不是账号字段，而是账号绑定的 egress cell 上的 `labels.lane`。
+
+## 核心事实
+
+- stable axis: surface 调度逻辑在 `cell.labels.lane`
+- change axis: `lane` 取值从 `<unset>` / `compat` / `all` 之间切换
+- invariant: 必须通过当前 active slot 的 admin API 更新，不能直接改 SQLite
+
+当前逻辑是：
+
+- `lane=<unset>`: 默认 `native-only`
+- `lane=compat`: `compat-only`
+- `lane=all`: 同时接受 `native` 和 `compat`
+
+不要把这件事理解成“给账号改一个 compat 开关”。账号自己没有这个字段。
+
+## 风险边界
+
+- 这是 cell 级切换，不是账号级切换。
+- 如果一个 cell 绑了多个账号，改 `lane` 会一起影响该 cell 上的所有账号。
+- 只有在目标账号绑定的是独占 cell 时，才适合把它当成“给某个账号切换 surface”。
+- 不要直接改数据库。直接改 SQLite 不会刷新活跃进程内存态，蓝绿下还容易改到不生效实例。
+- 蓝绿部署下只改当前 active slot。inactive slot 不对外提供服务，改它没有立即效果。
+
+## 推荐做法
+
+用仓库脚本：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane unset
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane compat
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane all
+```
+
+参数含义：
+
+- `--remote`: SSH 别名或主机，例如 `ccc`
+- `--account`: 账号 `email` 或账号 `id`
+- `--lane unset`: 删除 `lane`，回到默认 `native-only`
+- `--lane compat`: 切成 `compat-only`
+- `--lane all`: 双开 `native` + `compat`
+
+脚本行为：
+
+- 自动读取远端 `/var/lib/llm-broker/bluegreen/active-slot`
+- 自动命中 active slot 对应端口
+- 通过 admin API 读取账号和 cell 当前状态
+- 默认拒绝修改共享 cell
+- 只改 `labels.lane`，保留该 cell 其余 `name/status/proxy/labels`
+- 写入后回读账号可用面，输出 `available_native` / `available_compat`
+
+如果明确知道目标 cell 是共享的，并且你就是要一起改，可以显式加：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane compat --allow-shared-cell
+```
+
+## 为什么 `native` 推荐用 `unset`
+
+代码里 `native` 和 `<unset>` 对 native surface 都是可用的，但 `<unset>` 状态更干净，符合项目一贯偏好：
+
+- 少一个多余状态
+- 少一层人为约定
+- 更接近“默认 native”的真实语义
+
+所以脚本虽然接受 `--lane native`，实际会把它归一化成删除 `lane`。
+
+## 例子
+
+把 `kun` 从 `compat-only` 切回 `native-only`：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane unset
+```
+
+把 `kun` 恢复成 `compat-only`：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane compat
+```
+
+把 `kun` 开成双面：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane all
+```
+
+## 验证
+
+脚本执行后会直接输出：
+
+- 当前 active slot 和命中的端口
+- 目标账号 / cell
+- `lane` 的前后变化
+- 写入后的 `available_native`
+- 写入后的 `available_compat`
+
+如果你要手动复核，可以再跑一次 dry-run：
+
+```bash
+scripts/set-account-cell-lane.sh --remote ccc --account kun --lane compat --dry-run
+```
+
+`dry-run` 只做读取和解析，不会实际写入。

--- a/docs/superpowers/plans/2026-04-25-local-cell-watchdog.md
+++ b/docs/superpowers/plans/2026-04-25-local-cell-watchdog.md
@@ -1,0 +1,112 @@
+# Local Cell Watchdog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 broker 宿主机增加定时自愈 watchdog，持续修复 `local-danted` cell 的 source IPv6 与本地 danted 服务故障。
+
+**Architecture:** 以独立命令形式实现 watchdog，通过 broker admin API 读取和验证 cell，通过宿主机命令修复 `eth0` `/128` 地址和对应的 `danted` systemd unit。broker core 不感知任何宿主机修复细节。
+
+**Tech Stack:** Go 1.24、标准库 `net/http`/`os/exec`/`log/slog`、systemd service/timer
+
+---
+
+### Task 1: 定义纯逻辑边界
+
+**Files:**
+- Create: `internal/localcellwatchdog/watchdog.go`
+- Test: `internal/localcellwatchdog/watchdog_test.go`
+
+- [ ] **Step 1: 写失败用例**
+
+  覆盖：
+  - 只选择 `transport=local-danted && proxy.host=127.0.0.1` 的 active socks5 cell
+  - `11080/11082/11083` 到 systemd unit 的映射
+  - 缺失 `labels.ipv6`、未知端口时不进入修复
+
+- [ ] **Step 2: 跑测试确认失败**
+
+  Run: `go test ./internal/localcellwatchdog -run Test -count=1`
+
+- [ ] **Step 3: 写最小实现**
+
+  提供：
+  - 目标 cell 选择
+  - port -> unit
+  - 单轮修复决策所需的数据结构
+
+- [ ] **Step 4: 跑测试确认通过**
+
+  Run: `go test ./internal/localcellwatchdog -run Test -count=1`
+
+### Task 2: 实现 watchdog 命令
+
+**Files:**
+- Create: `cmd/local-cell-watchdog/main.go`
+- Modify: `internal/localcellwatchdog/watchdog.go`
+- Test: `internal/localcellwatchdog/watchdog_test.go`
+
+- [ ] **Step 1: 写失败用例**
+
+  覆盖：
+  - 初测失败时会尝试补 IPv6、重启服务、复测、清 cooldown
+  - 初测成功但有 cooldown 时会清 cooldown
+  - 复测失败时不会误清 cooldown
+
+- [ ] **Step 2: 跑测试确认失败**
+
+  Run: `go test ./internal/localcellwatchdog -run TestHeal -count=1`
+
+- [ ] **Step 3: 写最小实现**
+
+  实现：
+  - admin API client
+  - runner/exec 抽象
+  - 单轮检查/修复/复测
+  - 结构化日志
+
+- [ ] **Step 4: 跑测试确认通过**
+
+  Run: `go test ./internal/localcellwatchdog -count=1`
+
+### Task 3: 加安装资产
+
+**Files:**
+- Create: `ops/systemd/local-cell-watchdog.service`
+- Create: `ops/systemd/local-cell-watchdog.timer`
+- Create: `scripts/install-local-cell-watchdog.sh`
+
+- [ ] **Step 1: 写最小安装资产**
+
+  资产需要：
+  - `/usr/local/bin/local-cell-watchdog` 可执行
+  - service 为 oneshot
+  - timer 每 2 分钟触发
+  - 安装脚本负责 build / copy / daemon-reload / enable --now
+
+- [ ] **Step 2: 做本地静态检查**
+
+  Run: `sed -n '1,220p' ops/systemd/local-cell-watchdog.service ops/systemd/local-cell-watchdog.timer scripts/install-local-cell-watchdog.sh`
+
+### Task 4: 验证与部署
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-25-local-cell-watchdog-design.md`
+
+- [ ] **Step 1: 跑完整测试**
+
+  Run: `go test ./internal/localcellwatchdog ./cmd/local-cell-watchdog -count=1`
+
+- [ ] **Step 2: 构建命令**
+
+  Run: `go build ./cmd/local-cell-watchdog`
+
+- [ ] **Step 3: 安装到 `ccc`**
+
+  Run: `bash scripts/install-local-cell-watchdog.sh ccc`
+
+- [ ] **Step 4: 做故障注入验证**
+
+  在 `ccc`：
+  - 删除一个 `/128`
+  - `systemctl start local-cell-watchdog.service`
+  - 验证 cell test 成功、cooldown 清空

--- a/docs/superpowers/specs/2026-04-25-local-cell-watchdog-design.md
+++ b/docs/superpowers/specs/2026-04-25-local-cell-watchdog-design.md
@@ -1,0 +1,118 @@
+# Local Cell Watchdog Design
+
+**日期：** 2026-04-25
+
+## 目标
+
+为 `labels.transport=local-danted` 且 `proxy.host=127.0.0.1` 的 broker egress cell 增加宿主机侧 watchdog，持续保证：
+
+- cell 的真实连通性不丢
+- 宿主机 `/128` source IPv6 不因网络重配而失效
+- 因链路故障产生的 cell cooldown 在恢复后自动收口
+
+## 稳定轴 / 变化轴 / 不变量
+
+- 稳定轴：cell 可用性的真相是 `POST /admin/egress/cells/{id}/test`
+- 变化轴：`eth0` 上的 `/128` 地址、本地 `danted-*` 进程、cell cooldown
+- 不变量：`active` 的 `local-danted` cell 必须可通过 admin test 成功拨通；恢复后不应继续保留过期 cooldown
+
+## 边界
+
+这不是 broker core 逻辑。
+
+- watchdog 运行在 broker 宿主机
+- 通过 broker admin API 读取/验证/清理 cell 状态
+- 通过宿主机命令修复网络与 `danted` 服务
+- 不进入 `pool` / `relay` / `driver` 增加 provider 特例
+- 不理解账号、模型、provider 协议
+
+## 输入真相
+
+- cell 列表：`GET /admin/egress/cells`
+- 可用性探针：`POST /admin/egress/cells/{id}/test`
+- cooldown 收口：`POST /admin/egress/cells/{id}/clear-cooldown`
+- source IPv6：cell `labels.ipv6`
+- 本地监听端口：cell `proxy.port`
+
+## 选择规则
+
+仅处理满足下列条件的 cell：
+
+- `status == active`
+- `proxy.type == socks5`
+- `proxy.host == 127.0.0.1`
+- `labels.transport == local-danted`
+- `labels.ipv6` 非空
+- `proxy.port > 0`
+
+## 自愈流程
+
+每轮 watchdog 对目标 cell 逐个执行：
+
+1. 先做 cell test
+2. 若成功：
+   - 若 cell 有 cooldown，则调用 clear-cooldown
+   - 记录恢复日志
+3. 若失败：
+   - 检查 `eth0` 是否已挂载 `labels.ipv6/128`
+   - 若缺失则补回 `/128`
+   - 按约定映射出本地 `danted-*` unit 并重启
+   - 再次执行 cell test
+4. 复测成功：
+   - 清理 cooldown
+   - 记录自愈成功日志
+5. 复测失败：
+   - 保留失败状态
+   - 记录结构化错误日志
+
+## unit 映射
+
+本次只覆盖当前已知本地 unit：
+
+- `11080 -> danted-linda.service`
+- `11082 -> danted-cell-uk-linode-02-local.service`
+- `11083 -> danted-cell-uk-linode-03-local.service`
+
+后续若新增 local cell，应把“port -> unit”映射扩展到同一位置，不分散。
+
+## 运行形态
+
+- 仓库内实现一个独立命令：`cmd/local-cell-watchdog`
+- 宿主机安装为 `/usr/local/bin/local-cell-watchdog`
+- 用 `systemd` 提供：
+  - `local-cell-watchdog.service`
+  - `local-cell-watchdog.timer`
+- 周期：每 2 分钟
+- 允许手动立即触发：`systemctl start local-cell-watchdog.service`
+
+## 可观测性
+
+日志要求：
+
+- 结构化 key-value
+- 至少包含：`cell_id`、`cell_name`、`ipv6`、`proxy_port`、`service_name`、`stage`、`result`
+- 自愈前后要有因果链：初测失败 -> 修复动作 -> 复测结果 -> cooldown 清理结果
+
+## 测试
+
+### 自动化
+
+- 纯逻辑测试：
+  - cell 筛选
+  - port -> unit 映射
+  - 成功/失败/复测成功的决策路径
+
+### 集成验证
+
+在 `ccc` 上做人为故障注入：
+
+- 手工删掉 `eth0` 上某个 `/128`
+- 运行 watchdog
+- 验证地址补回、对应 `danted` 重启、cell test 变为成功、cooldown 被清理
+
+## 非目标
+
+- 不做 provider 级健康判定
+- 不修改 broker 调度逻辑
+- 不把宿主机网络修复逻辑塞进 broker core
+- 不引入无限重试或守护常驻进程

--- a/internal/driver/claude_build_request_test.go
+++ b/internal/driver/claude_build_request_test.go
@@ -97,6 +97,27 @@ func TestClaudeBuildRequestNormalizesSystemEnvelopeForSonnet(t *testing.T) {
 	})
 }
 
+func TestClaudeBuildRequestNormalizesSystemEnvelopeForOpus47(t *testing.T) {
+	body := buildClaudeRequestBody(t, "claude-opus-4-7", map[string]interface{}{
+		"max_tokens": 1,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "hello"},
+		},
+	})
+	got := buildClaudeUpstreamBody(t, body, false)
+
+	if got["model"] != "claude-opus-4-7" {
+		t.Fatalf("model = %#v", got["model"])
+	}
+	system := mustSystemBlocks(t, got["system"])
+	if len(system) != 1 {
+		t.Fatalf("len(system) = %d, want 1", len(system))
+	}
+	if text, _ := system[0]["text"].(string); text != claudeCodeSystemBlockText {
+		t.Fatalf("system[0].text = %q", text)
+	}
+}
+
 func TestClaudeBuildRequestLeavesHaikuAndCountTokensUnchanged(t *testing.T) {
 	t.Run("haiku request stays untouched", func(t *testing.T) {
 		body := buildClaudeRequestBody(t, "claude-haiku-4-5", map[string]interface{}{

--- a/internal/driver/claude_models.go
+++ b/internal/driver/claude_models.go
@@ -14,6 +14,7 @@ type claudeModelEntry struct {
 }
 
 var claudeModelEntries = []claudeModelEntry{
+	{PublicID: "claude-opus-4-7", UpstreamID: "claude-opus-4-7", ContextWindow: 200000, Advertise: true},
 	{PublicID: "claude-opus-4-6", UpstreamID: "claude-opus-4-6", ContextWindow: 200000, Advertise: true},
 	{PublicID: "claude-opus-4-5", UpstreamID: "claude-opus-4-5", ContextWindow: 200000, Advertise: true},
 	{PublicID: "claude-opus-4-1", UpstreamID: "claude-opus-4-1", ContextWindow: 200000, Advertise: true},

--- a/internal/driver/codex_descriptor.go
+++ b/internal/driver/codex_descriptor.go
@@ -42,6 +42,7 @@ func (d *CodexDriver) Info() ProviderInfo {
 
 func (d *CodexDriver) Models() []Model {
 	return []Model{
+		{ID: "gpt-5.5", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},
 		{ID: "gpt-5.4", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 1050000},
 		{ID: "gpt-5.4-mini", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 1050000},
 		{ID: "gpt-5.3-codex", Object: "model", Created: 1709164800, OwnedBy: "openai", ContextWindow: 400000},

--- a/internal/driver/codex_test.go
+++ b/internal/driver/codex_test.go
@@ -154,10 +154,11 @@ func TestCanServe_PerFamily(t *testing.T) {
 		model string
 		want  bool
 	}{
-		{"gpt-5.3-codex", false},       // standard family exhausted
-		{"gpt-5.4", false},             // standard family
-		{"gpt-5.3-codex-spark", true},  // spark family has capacity
-		{"codex-1", false},             // standard family
+		{"gpt-5.5", false},            // standard family
+		{"gpt-5.3-codex", false},      // standard family exhausted
+		{"gpt-5.4", false},            // standard family
+		{"gpt-5.3-codex-spark", true}, // spark family has capacity
+		{"codex-1", false},            // standard family
 	}
 	for _, tt := range tests {
 		if got := d.CanServe(state, tt.model, now); got != tt.want {
@@ -301,6 +302,7 @@ func TestCodexModelFamily(t *testing.T) {
 		model string
 		want  string
 	}{
+		{"gpt-5.5", ""},
 		{"gpt-5.3-codex", ""},
 		{"gpt-5.4", ""},
 		{"gpt-5.3-codex-spark", "bengalfox"},
@@ -313,6 +315,21 @@ func TestCodexModelFamily(t *testing.T) {
 			t.Errorf("codexModelFamily(%q) = %q, want %q", tt.model, got, tt.want)
 		}
 	}
+}
+
+func TestCodexModelsIncludesGPT55(t *testing.T) {
+	d := NewCodexDriver(CodexConfig{})
+	models := d.Models()
+	for _, model := range models {
+		if model.ID != "gpt-5.5" {
+			continue
+		}
+		if model.ContextWindow != 400000 {
+			t.Fatalf("gpt-5.5 context_window = %d, want %d", model.ContextWindow, 400000)
+		}
+		return
+	}
+	t.Fatal("gpt-5.5 missing from codex model catalog")
 }
 
 func TestDiscoverCodexFamilyPrefixes(t *testing.T) {

--- a/internal/localcellwatchdog/watchdog.go
+++ b/internal/localcellwatchdog/watchdog.go
@@ -1,0 +1,231 @@
+package localcellwatchdog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type Proxy struct {
+	Type string `json:"type,omitempty"`
+	Host string `json:"host,omitempty"`
+	Port int    `json:"port,omitempty"`
+}
+
+type Cell struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Status        string            `json:"status"`
+	Proxy         *Proxy            `json:"proxy,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+	CooldownUntil *time.Time        `json:"cooldown_until,omitempty"`
+}
+
+type ProbeResult struct {
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+	LatencyMs int64  `json:"latency_ms,omitempty"`
+}
+
+type Client interface {
+	ListCells(ctx context.Context) ([]Cell, error)
+	TestCell(ctx context.Context, cellID string) (ProbeResult, error)
+	ClearCooldown(ctx context.Context, cellID string) error
+}
+
+type Runner interface {
+	IPv6Present(ctx context.Context, iface, ipv6 string) (bool, error)
+	AddIPv6(ctx context.Context, iface, ipv6 string) error
+	RestartService(ctx context.Context, service string) error
+}
+
+type Options struct {
+	Iface              string
+	Client             Client
+	Runner             Runner
+	Logger             *slog.Logger
+	RepairProbeRetries int
+	RepairProbeDelay   time.Duration
+}
+
+type Watchdog struct {
+	iface              string
+	client             Client
+	runner             Runner
+	logger             *slog.Logger
+	repairProbeRetries int
+	repairProbeDelay   time.Duration
+}
+
+func New(opts Options) *Watchdog {
+	if opts.Iface == "" {
+		opts.Iface = "eth0"
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	if opts.RepairProbeRetries <= 0 {
+		opts.RepairProbeRetries = 5
+	}
+	if opts.RepairProbeDelay < 0 {
+		opts.RepairProbeDelay = 0
+	}
+	if opts.RepairProbeDelay == 0 {
+		opts.RepairProbeDelay = 300 * time.Millisecond
+	}
+	return &Watchdog{
+		iface:              opts.Iface,
+		client:             opts.Client,
+		runner:             opts.Runner,
+		logger:             opts.Logger,
+		repairProbeRetries: opts.RepairProbeRetries,
+		repairProbeDelay:   opts.RepairProbeDelay,
+	}
+}
+
+func TargetCells(cells []Cell) []Cell {
+	targets := make([]Cell, 0, len(cells))
+	for _, cell := range cells {
+		if !isTargetCell(cell) {
+			continue
+		}
+		targets = append(targets, cell)
+	}
+	return targets
+}
+
+func ServiceNameForPort(port int) (string, bool) {
+	switch port {
+	case 11080:
+		return "danted-linda.service", true
+	case 11082:
+		return "danted-cell-uk-linode-02-local.service", true
+	case 11083:
+		return "danted-cell-uk-linode-03-local.service", true
+	default:
+		return "", false
+	}
+}
+
+func (w *Watchdog) RunOnce(ctx context.Context) error {
+	cells, err := w.client.ListCells(ctx)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	for _, cell := range TargetCells(cells) {
+		if err := w.reconcileCell(ctx, cell); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			w.logger.Error("local cell watchdog failed", "cell_id", cell.ID, "cell_name", cell.Name, "error", err)
+		}
+	}
+	return firstErr
+}
+
+func (w *Watchdog) reconcileCell(ctx context.Context, cell Cell) error {
+	ipv6 := strings.TrimSpace(cell.Labels["ipv6"])
+	service, ok := ServiceNameForPort(cell.Proxy.Port)
+	if !ok || ipv6 == "" {
+		w.logger.Warn("local cell watchdog skipped", "cell_id", cell.ID, "proxy_port", cell.Proxy.Port, "ipv6", ipv6)
+		return nil
+	}
+
+	probe, err := w.client.TestCell(ctx, cell.ID)
+	if err != nil {
+		return err
+	}
+	if probe.OK {
+		return w.clearCooldownIfNeeded(ctx, cell, "healthy")
+	}
+
+	present, err := w.runner.IPv6Present(ctx, w.iface, ipv6)
+	if err != nil {
+		return err
+	}
+	if !present {
+		if err := w.runner.AddIPv6(ctx, w.iface, ipv6); err != nil {
+			return err
+		}
+		w.logger.Info("local cell watchdog added ipv6", "cell_id", cell.ID, "ipv6", ipv6, "iface", w.iface)
+	}
+
+	if err := w.runner.RestartService(ctx, service); err != nil {
+		return err
+	}
+	w.logger.Warn("local cell watchdog restarted service", "cell_id", cell.ID, "service_name", service, "stage", "repair")
+
+	probe, err = w.probeAfterRepair(ctx, cell.ID)
+	if err != nil {
+		return err
+	}
+	if !probe.OK {
+		w.logger.Error("local cell watchdog retest failed", "cell_id", cell.ID, "service_name", service, "result", "failed", "error", probe.Error)
+		return nil
+	}
+	return w.clearCooldownIfNeeded(ctx, cell, "recovered")
+}
+
+func (w *Watchdog) probeAfterRepair(ctx context.Context, cellID string) (ProbeResult, error) {
+	attempts := w.repairProbeRetries
+	var last ProbeResult
+	for i := 0; i < attempts; i++ {
+		probe, err := w.client.TestCell(ctx, cellID)
+		if err != nil {
+			return ProbeResult{}, err
+		}
+		last = probe
+		if probe.OK {
+			return probe, nil
+		}
+		if i == attempts-1 {
+			break
+		}
+		timer := time.NewTimer(w.repairProbeDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ProbeResult{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return last, nil
+}
+
+func (w *Watchdog) clearCooldownIfNeeded(ctx context.Context, cell Cell, stage string) error {
+	if cell.CooldownUntil == nil {
+		w.logger.Info("local cell watchdog probe ok", "cell_id", cell.ID, "stage", stage, "result", "ok")
+		return nil
+	}
+	if err := w.client.ClearCooldown(ctx, cell.ID); err != nil {
+		return err
+	}
+	w.logger.Info("local cell watchdog cleared cooldown", "cell_id", cell.ID, "stage", stage, "result", "ok")
+	return nil
+}
+
+func isTargetCell(cell Cell) bool {
+	if strings.TrimSpace(cell.Status) != "active" {
+		return false
+	}
+	if cell.Proxy == nil {
+		return false
+	}
+	if strings.TrimSpace(cell.Proxy.Type) != "socks5" {
+		return false
+	}
+	if strings.TrimSpace(cell.Proxy.Host) != "127.0.0.1" {
+		return false
+	}
+	if cell.Proxy.Port <= 0 {
+		return false
+	}
+	if strings.TrimSpace(cell.Labels["transport"]) != "local-danted" {
+		return false
+	}
+	return strings.TrimSpace(cell.Labels["ipv6"]) != ""
+}

--- a/internal/localcellwatchdog/watchdog_test.go
+++ b/internal/localcellwatchdog/watchdog_test.go
@@ -1,0 +1,285 @@
+package localcellwatchdog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTargetCellsFiltersLocalDantedActiveSocks5(t *testing.T) {
+	now := time.Now().UTC()
+	cells := []Cell{
+		{
+			ID:     "cell-ok",
+			Name:   "UK Linode 01(local)",
+			Status: "active",
+			Proxy:  &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+			Labels: map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::100"},
+		},
+		{
+			ID:     "cell-disabled",
+			Status: "disabled",
+			Proxy:  &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11081},
+			Labels: map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::101"},
+		},
+		{
+			ID:     "cell-http",
+			Status: "active",
+			Proxy:  &Proxy{Type: "http", Host: "127.0.0.1", Port: 11082},
+			Labels: map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::102"},
+		},
+		{
+			ID:     "cell-remote",
+			Status: "active",
+			Proxy:  &Proxy{Type: "socks5", Host: "10.0.0.2", Port: 12081},
+			Labels: map[string]string{"transport": "wg-direct", "ipv6": "2600:3c1a:e001:16::101"},
+		},
+		{
+			ID:            "cell-missing-ipv6",
+			Status:        "active",
+			Proxy:         &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11083},
+			Labels:        map[string]string{"transport": "local-danted"},
+			CooldownUntil: &now,
+		},
+	}
+
+	got := TargetCells(cells)
+	if len(got) != 1 {
+		t.Fatalf("TargetCells() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "cell-ok" {
+		t.Fatalf("TargetCells()[0].ID = %q, want %q", got[0].ID, "cell-ok")
+	}
+}
+
+func TestServiceNameForPort(t *testing.T) {
+	tests := []struct {
+		port int
+		want string
+		ok   bool
+	}{
+		{port: 11080, want: "danted-linda.service", ok: true},
+		{port: 11082, want: "danted-cell-uk-linode-02-local.service", ok: true},
+		{port: 11083, want: "danted-cell-uk-linode-03-local.service", ok: true},
+		{port: 9999, want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		got, ok := ServiceNameForPort(tt.port)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("ServiceNameForPort(%d) = (%q, %v), want (%q, %v)", tt.port, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestRunOnceRepairsFailedCellAndClearsCooldown(t *testing.T) {
+	now := time.Now().UTC()
+	cell := Cell{
+		ID:            "cell-uk-linode-01",
+		Name:          "UK Linode 01(local)",
+		Status:        "active",
+		Proxy:         &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		Labels:        map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::100"},
+		CooldownUntil: &now,
+	}
+
+	client := &fakeClient{
+		cells: []Cell{cell},
+		results: map[string][]ProbeResult{
+			cell.ID: {
+				{OK: false, Error: "network unreachable"},
+				{OK: true, LatencyMs: 7},
+			},
+		},
+	}
+	runner := &fakeRunner{present: map[string]bool{}}
+	w := New(Options{
+		Iface:  "eth0",
+		Client: client,
+		Runner: runner,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(runner.addedIPv6, []string{"eth0|2600:3c13:e001:ae::100"}) {
+		t.Fatalf("addedIPv6 = %#v", runner.addedIPv6)
+	}
+	if !reflect.DeepEqual(runner.restartedServices, []string{"danted-linda.service"}) {
+		t.Fatalf("restartedServices = %#v", runner.restartedServices)
+	}
+	if !reflect.DeepEqual(client.clearedCooldown, []string{cell.ID}) {
+		t.Fatalf("clearedCooldown = %#v", client.clearedCooldown)
+	}
+}
+
+func TestRunOnceClearsCooldownWhenHealthy(t *testing.T) {
+	now := time.Now().UTC()
+	cell := Cell{
+		ID:            "cell-uk-linode-02",
+		Status:        "active",
+		Proxy:         &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11082},
+		Labels:        map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::101"},
+		CooldownUntil: &now,
+	}
+
+	client := &fakeClient{
+		cells: []Cell{cell},
+		results: map[string][]ProbeResult{
+			cell.ID: {
+				{OK: true, LatencyMs: 9},
+			},
+		},
+	}
+	runner := &fakeRunner{present: map[string]bool{"2600:3c13:e001:ae::101": true}}
+	w := New(Options{
+		Iface:  "eth0",
+		Client: client,
+		Runner: runner,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+
+	if len(runner.addedIPv6) != 0 {
+		t.Fatalf("addedIPv6 = %#v, want none", runner.addedIPv6)
+	}
+	if len(runner.restartedServices) != 0 {
+		t.Fatalf("restartedServices = %#v, want none", runner.restartedServices)
+	}
+	if !reflect.DeepEqual(client.clearedCooldown, []string{cell.ID}) {
+		t.Fatalf("clearedCooldown = %#v", client.clearedCooldown)
+	}
+}
+
+func TestRunOnceLeavesCooldownWhenRetestStillFails(t *testing.T) {
+	now := time.Now().UTC()
+	cell := Cell{
+		ID:            "cell-uk-linode-03",
+		Status:        "active",
+		Proxy:         &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11083},
+		Labels:        map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::102"},
+		CooldownUntil: &now,
+	}
+
+	client := &fakeClient{
+		cells: []Cell{cell},
+		results: map[string][]ProbeResult{
+			cell.ID: {
+				{OK: false, Error: "network unreachable"},
+				{OK: false, Error: "still unreachable"},
+			},
+		},
+	}
+	runner := &fakeRunner{present: map[string]bool{"2600:3c13:e001:ae::102": true}}
+	w := New(Options{
+		Iface:  "eth0",
+		Client: client,
+		Runner: runner,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(runner.restartedServices, []string{"danted-cell-uk-linode-03-local.service"}) {
+		t.Fatalf("restartedServices = %#v", runner.restartedServices)
+	}
+	if len(client.clearedCooldown) != 0 {
+		t.Fatalf("clearedCooldown = %#v, want none", client.clearedCooldown)
+	}
+}
+
+func TestRunOnceRetriesProbeAfterRestart(t *testing.T) {
+	now := time.Now().UTC()
+	cell := Cell{
+		ID:            "cell-uk-linode-02",
+		Status:        "active",
+		Proxy:         &Proxy{Type: "socks5", Host: "127.0.0.1", Port: 11082},
+		Labels:        map[string]string{"transport": "local-danted", "ipv6": "2600:3c13:e001:ae::101"},
+		CooldownUntil: &now,
+	}
+
+	client := &fakeClient{
+		cells: []Cell{cell},
+		results: map[string][]ProbeResult{
+			cell.ID: {
+				{OK: false, Error: "network unreachable"},
+				{OK: false, Error: "dial tcp 127.0.0.1:11082: connect: connection refused"},
+				{OK: true, LatencyMs: 8},
+			},
+		},
+	}
+	runner := &fakeRunner{present: map[string]bool{"2600:3c13:e001:ae::101": true}}
+	w := New(Options{
+		Iface:  "eth0",
+		Client: client,
+		Runner: runner,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(runner.restartedServices, []string{"danted-cell-uk-linode-02-local.service"}) {
+		t.Fatalf("restartedServices = %#v", runner.restartedServices)
+	}
+	if !reflect.DeepEqual(client.clearedCooldown, []string{cell.ID}) {
+		t.Fatalf("clearedCooldown = %#v", client.clearedCooldown)
+	}
+}
+
+type fakeClient struct {
+	cells           []Cell
+	results         map[string][]ProbeResult
+	clearedCooldown []string
+}
+
+func (f *fakeClient) ListCells(context.Context) ([]Cell, error) {
+	return append([]Cell(nil), f.cells...), nil
+}
+
+func (f *fakeClient) TestCell(_ context.Context, cellID string) (ProbeResult, error) {
+	queue := f.results[cellID]
+	if len(queue) == 0 {
+		return ProbeResult{}, nil
+	}
+	result := queue[0]
+	f.results[cellID] = queue[1:]
+	return result, nil
+}
+
+func (f *fakeClient) ClearCooldown(_ context.Context, cellID string) error {
+	f.clearedCooldown = append(f.clearedCooldown, cellID)
+	return nil
+}
+
+type fakeRunner struct {
+	present           map[string]bool
+	addedIPv6         []string
+	restartedServices []string
+}
+
+func (f *fakeRunner) IPv6Present(_ context.Context, iface, ipv6 string) (bool, error) {
+	return f.present[ipv6], nil
+}
+
+func (f *fakeRunner) AddIPv6(_ context.Context, iface, ipv6 string) error {
+	f.addedIPv6 = append(f.addedIPv6, iface+"|"+ipv6)
+	f.present[ipv6] = true
+	return nil
+}
+
+func (f *fakeRunner) RestartService(_ context.Context, service string) error {
+	f.restartedServices = append(f.restartedServices, service)
+	return nil
+}

--- a/internal/pool/pool_schedule.go
+++ b/internal/pool/pool_schedule.go
@@ -53,6 +53,13 @@ func (p *Pool) allowedOnSurfaceLocked(acct *domain.Account, surface domain.Surfa
 	if surface == "" || surface == domain.SurfaceAll {
 		return true
 	}
+	// Hotfix: Claude compat failures on legacy-direct accounts are caused by
+	// coupling surface eligibility to cell lane. Keep this provider-specific
+	// escape hatch only until surface/account policy is moved out of cell lane
+	// and user pins become provider-scoped.
+	if acct != nil && acct.Provider == domain.ProviderClaude {
+		return surface == domain.SurfaceNative || surface == domain.SurfaceCompat
+	}
 
 	cell := p.cellForAccountLocked(acct)
 	lane := cellLane(cell)
@@ -212,6 +219,11 @@ func (p *Pool) PickForSurface(drv driver.SchedulerDriver, exclusions []Exclusion
 
 	if boundAccountID != "" {
 		acct, ok := p.accounts[boundAccountID]
+		// Hotfix: bound_account_id is global today. Ignore it for other
+		// providers until user pins are migrated to provider-scoped storage.
+		if ok && acct.Provider != provider {
+			ok = false
+		}
 		if ok {
 			if _, blocked := excludedAccounts[acct.ID]; blocked {
 				return nil, fmt.Errorf("bound account %s excluded", boundAccountID)

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -96,6 +96,7 @@ func (m *mockDriver) CalcCost(_ string, _ *driver.Usage) float64           { ret
 func (m *mockDriver) GetUtilization(_ json.RawMessage) []driver.UtilWindow { return nil }
 
 var testDriver = &mockDriver{provider: domain.ProviderClaude}
+var testGeminiDriver = &mockDriver{provider: domain.ProviderGemini}
 
 func newTestPool(t *testing.T, accounts ...*domain.Account) *Pool {
 	t.Helper()
@@ -222,7 +223,7 @@ func TestPick_SkipsUnavailableCell(t *testing.T) {
 	}
 }
 
-func TestPickForSurface_SeparatesNativeAndCompatLanes(t *testing.T) {
+func TestPickForSurface_ClaudeIgnoresCellLanes(t *testing.T) {
 	native := activeAccount("native", "native@x")
 	native.Priority = 80
 	native.CellID = "cell-native"
@@ -261,8 +262,8 @@ func TestPickForSurface_SeparatesNativeAndCompatLanes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PickForSurface(native): %v", err)
 	}
-	if gotNative.ID != "native" {
-		t.Fatalf("PickForSurface(native) = %s, want native", gotNative.ID)
+	if gotNative.ID != "compat" {
+		t.Fatalf("PickForSurface(native) = %s, want compat", gotNative.ID)
 	}
 
 	gotCompat, err := p.PickForSurface(testDriver, nil, "claude-haiku", "", domain.SurfaceCompat)
@@ -274,7 +275,7 @@ func TestPickForSurface_SeparatesNativeAndCompatLanes(t *testing.T) {
 	}
 }
 
-func TestSurfaceAvailabilityMap_RespectsSurfaceLanes(t *testing.T) {
+func TestSurfaceAvailabilityMap_ClaudeIgnoresCellLanes(t *testing.T) {
 	native := activeAccount("native-avail", "native@x")
 	compat := activeAccount("compat-avail", "compat@x")
 	compat.CellID = "cell-compat"
@@ -300,14 +301,87 @@ func TestSurfaceAvailabilityMap_RespectsSurfaceLanes(t *testing.T) {
 	if !availability[native.ID].Native {
 		t.Fatal("native legacy-direct account should be native-available")
 	}
-	if availability[native.ID].Compat {
-		t.Fatal("native legacy-direct account should not be compat-available")
+	if !availability[native.ID].Compat {
+		t.Fatal("native legacy-direct account should be compat-available")
 	}
-	if availability[compat.ID].Native {
-		t.Fatal("compat lane account should not be native-available")
+	if !availability[compat.ID].Native {
+		t.Fatal("compat lane account should be native-available")
 	}
 	if !availability[compat.ID].Compat {
 		t.Fatal("compat lane account should be compat-available")
+	}
+}
+
+func TestSurfaceAvailabilityMap_NonClaudeStillRespectsSurfaceLanes(t *testing.T) {
+	native := &domain.Account{
+		ID:       "gem-native",
+		Email:    "native@gem",
+		Provider: domain.ProviderGemini,
+		Subject:  "gem-native",
+		Status:   domain.StatusActive,
+		Priority: 50,
+	}
+	compat := &domain.Account{
+		ID:       "gem-compat",
+		Email:    "compat@gem",
+		Provider: domain.ProviderGemini,
+		Subject:  "gem-compat",
+		Status:   domain.StatusActive,
+		Priority: 50,
+		CellID:   "cell-compat",
+	}
+
+	p := newTestPool(t, native, compat)
+	p.SetDrivers(map[domain.Provider]driver.SchedulerDriver{
+		domain.ProviderGemini: testGeminiDriver,
+	})
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-compat",
+		Name:      "compat",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "10.0.0.3", Port: 11082},
+		Labels:    map[string]string{"lane": "compat"},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-compat): %v", err)
+	}
+
+	availability := p.SurfaceAvailabilityMap()
+
+	if !availability[native.ID].Native {
+		t.Fatal("native legacy-direct gemini account should be native-available")
+	}
+	if availability[native.ID].Compat {
+		t.Fatal("native legacy-direct gemini account should not be compat-available")
+	}
+	if availability[compat.ID].Native {
+		t.Fatal("compat lane gemini account should not be native-available")
+	}
+	if !availability[compat.ID].Compat {
+		t.Fatal("compat lane gemini account should be compat-available")
+	}
+}
+
+func TestPickForSurface_IgnoresBoundAccountFromOtherProvider(t *testing.T) {
+	claude := activeAccount("claude-bound", "claude@x")
+	gemini := &domain.Account{
+		ID:       "gemini-live",
+		Email:    "gemini@x",
+		Provider: domain.ProviderGemini,
+		Subject:  "gemini-live",
+		Status:   domain.StatusActive,
+		Priority: 50,
+	}
+
+	p := newTestPool(t, claude, gemini)
+
+	got, err := p.PickForSurface(testGeminiDriver, nil, "gemini-2.5-flash", claude.ID, domain.SurfaceNative)
+	if err != nil {
+		t.Fatalf("PickForSurface(native, bound other provider): %v", err)
+	}
+	if got.ID != gemini.ID {
+		t.Fatalf("PickForSurface(native, bound other provider) = %s, want %s", got.ID, gemini.ID)
 	}
 }
 

--- a/internal/server/admin_activity.go
+++ b/internal/server/admin_activity.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"sort"
+
+	"github.com/yansircc/llm-broker/internal/domain"
+)
+
+func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	writeJSON(w, http.StatusOK, ActivityResponse{
+		Health:         s.buildHealthInfo(ctx),
+		Accounts:       s.activityAccounts(),
+		Users:          s.activityUsers(ctx),
+		Events:         s.dashboardEvents(20),
+		RecentFailures: s.activityRecentFailures(ctx, 30),
+	})
+}
+
+func (s *Server) handleActivityUsage(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.dashboardUsage(r.Context(), parseTZParam(r)))
+}
+
+func (s *Server) activityAccounts() []ActivityAccountRef {
+	accounts := s.pool.List()
+	views := make([]ActivityAccountRef, 0, len(accounts))
+	for _, acct := range accounts {
+		views = append(views, ActivityAccountRef{
+			ID:    acct.ID,
+			Email: acct.Email,
+		})
+	}
+	sort.Slice(views, func(i, j int) bool {
+		if views[i].Email != views[j].Email {
+			return views[i].Email < views[j].Email
+		}
+		return views[i].ID < views[j].ID
+	})
+	return views
+}
+
+func (s *Server) activityUsers(ctx context.Context) []ActivityUserRef {
+	users, err := s.store.ListUsers(ctx)
+	if err != nil {
+		return []ActivityUserRef{}
+	}
+	views := make([]ActivityUserRef, 0, len(users))
+	for _, user := range users {
+		views = append(views, ActivityUserRef{
+			ID:   user.ID,
+			Name: user.Name,
+		})
+	}
+	sort.Slice(views, func(i, j int) bool {
+		if views[i].Name != views[j].Name {
+			return views[i].Name < views[j].Name
+		}
+		return views[i].ID < views[j].ID
+	})
+	return views
+}
+
+func (s *Server) activityRecentFailures(ctx context.Context, limit int) []*domain.RequestLog {
+	logs, _, err := s.store.QueryRequestLogs(ctx, domain.RequestLogQuery{
+		FailuresOnly: true,
+		Limit:        limit,
+	})
+	if err != nil || logs == nil {
+		return []*domain.RequestLog{}
+	}
+	return logs
+}

--- a/internal/server/admin_dashboard.go
+++ b/internal/server/admin_dashboard.go
@@ -66,25 +66,7 @@ func (s *Server) dashboardUsers(ctx context.Context) []DashboardUser {
 	if err != nil {
 		slog.Warn("dashboard: list users failed", "error", err)
 	}
-	userCosts, err := s.store.QueryUserTotalCosts(ctx)
-	if err != nil {
-		slog.Warn("dashboard: query user costs failed", "error", err)
-	}
-
-	views := make([]DashboardUser, 0, len(users))
-	for _, user := range users {
-		views = append(views, DashboardUser{
-			ID:                user.ID,
-			Name:              user.Name,
-			Status:            user.Status,
-			AllowedSurface:    user.AllowedSurface,
-			BoundAccountID:    user.BoundAccountID,
-			BoundAccountEmail: s.boundAccountEmail(user.BoundAccountID),
-			LastActiveAt:      user.LastActiveAt,
-			TotalCost:         userCosts[user.ID],
-		})
-	}
-	return views
+	return s.userSummaryViews(users)
 }
 
 func (s *Server) dashboardEvents(limit int) []DashboardEvent {
@@ -224,6 +206,22 @@ func dashboardCellName(cell *domain.EgressCell, cellID string) string {
 		return "legacy direct"
 	}
 	return cellID
+}
+
+func (s *Server) userSummaryViews(users []*domain.User) []DashboardUser {
+	views := make([]DashboardUser, 0, len(users))
+	for _, user := range users {
+		views = append(views, DashboardUser{
+			ID:                user.ID,
+			Name:              user.Name,
+			Status:            user.Status,
+			AllowedSurface:    user.AllowedSurface,
+			BoundAccountID:    user.BoundAccountID,
+			BoundAccountEmail: s.boundAccountEmail(user.BoundAccountID),
+			LastActiveAt:      user.LastActiveAt,
+		})
+	}
+	return views
 }
 
 func dashboardCellRegion(cell *domain.EgressCell) string {

--- a/internal/server/admin_users.go
+++ b/internal/server/admin_users.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -85,10 +86,17 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 		writeAdminError(w, http.StatusInternalServerError, "internal_error", "failed to list users")
 		return
 	}
-	if users == nil {
-		users = []*domain.User{}
+	writeJSON(w, http.StatusOK, s.userSummaryViews(users))
+}
+
+func (s *Server) handleListUserTotalCosts(w http.ResponseWriter, r *http.Request) {
+	userIDs := parseCSVQuery(r.URL.Query().Get("ids"))
+	totals, err := s.store.QueryUserTotalCostsByIDs(r.Context(), userIDs)
+	if err != nil {
+		writeAdminError(w, http.StatusInternalServerError, "internal_error", "failed to query user total costs")
+		return
 	}
-	writeJSON(w, http.StatusOK, users)
+	writeJSON(w, http.StatusOK, UserTotalCostsResponse{Totals: totals})
 }
 
 func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
@@ -242,6 +250,27 @@ func generateUserToken(name string) (plaintext, hashStr, prefix string, err erro
 	hashStr = hex.EncodeToString(h[:])
 	prefix = fmt.Sprintf("tk_%s_%s...", name, hexStr[:4])
 	return plaintext, hashStr, prefix, nil
+}
+
+func parseCSVQuery(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -250,6 +250,101 @@ func TestDashboard_EventsIncludeUpstreamStatus(t *testing.T) {
 	}
 }
 
+func TestActivity_UsesLightweightShape(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-1",
+		Email:    "acct-1@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.CreateUser(context.Background(), &domain.User{
+		ID:        "u-1",
+		Name:      "alice",
+		Status:    "active",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.InsertRequestLog(context.Background(), &domain.RequestLog{
+		UserID:            "u-1",
+		AccountID:         "acct-1",
+		Provider:          "claude",
+		Surface:           "native",
+		Model:             "claude-sonnet-4-6",
+		Path:              "/v1/messages",
+		Status:            "upstream_403",
+		EffectKind:        "block",
+		UpstreamStatus:    http.StatusForbidden,
+		UpstreamErrorType: "blocked",
+		CreatedAt:         time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+	srv.bus.Publish(events.Event{
+		Type:      events.EventReject,
+		AccountID: "acct-1",
+		UserID:    "u-1",
+		Message:   "blocked request",
+		Timestamp: time.Now().UTC(),
+	})
+
+	w := httptest.NewRecorder()
+	srv.handleActivity(w, adminRequest("GET", "/admin/activity"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.Bytes()
+	assertJSONArray(t, body, "accounts")
+	assertJSONArray(t, body, "users")
+	assertJSONArray(t, body, "events")
+	assertJSONArray(t, body, "recent_failures")
+
+	if got := jsonPath(t, body, "accounts").([]interface{}); len(got) != 1 {
+		t.Fatalf("len(accounts) = %d, want 1", len(got))
+	}
+	if got := jsonPath(t, body, "users").([]interface{}); len(got) != 1 {
+		t.Fatalf("len(users) = %d, want 1", len(got))
+	}
+	if got := jsonPath(t, body, "recent_failures").([]interface{}); len(got) != 1 {
+		t.Fatalf("len(recent_failures) = %d, want 1", len(got))
+	}
+	if got := jsonPath(t, body, "accounts").([]interface{})[0].(map[string]interface{})["email"]; got != "acct-1@example.com" {
+		t.Fatalf("account email = %#v, want %q", got, "acct-1@example.com")
+	}
+	if got := jsonPath(t, body, "users").([]interface{})[0].(map[string]interface{})["name"]; got != "alice" {
+		t.Fatalf("user name = %#v, want %q", got, "alice")
+	}
+}
+
+func TestActivityUsage_EmptyData(t *testing.T) {
+	srv := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	srv.handleActivityUsage(w, adminRequest("GET", "/admin/activity/usage"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.Bytes()
+	var result interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatal(err)
+	}
+	arr, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("response is %T, expected array", result)
+	}
+	if len(arr) != 0 {
+		t.Fatalf("len(result) = %d, want 0", len(arr))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Account detail contract tests
 // ---------------------------------------------------------------------------
@@ -683,6 +778,106 @@ func TestListUsers_Empty(t *testing.T) {
 	}
 	if len(arr) != 0 {
 		t.Errorf("expected empty array, got %d elements", len(arr))
+	}
+}
+
+func TestListUsers_ReturnsUserSummaries(t *testing.T) {
+	srv := newTestServer(t)
+
+	acct := &domain.Account{
+		ID:        "acct-1",
+		Provider:  domain.ProviderClaude,
+		Subject:   "sub-1",
+		Email:     "bound@example.com",
+		Status:    domain.StatusActive,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := srv.pool.Add(acct); err != nil {
+		t.Fatal(err)
+	}
+
+	user := &domain.User{
+		ID:             "u-1",
+		Name:           "alice",
+		TokenHash:      tokenHash("user-token"),
+		TokenPrefix:    "tk_alice_abcd...",
+		Status:         "active",
+		AllowedSurface: domain.SurfaceCompat,
+		BoundAccountID: acct.ID,
+		CreatedAt:      time.Now().UTC(),
+	}
+	if err := srv.store.CreateUser(context.Background(), user); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleListUsers(w, adminRequest("GET", "/admin/users"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if got := result[0]["allowed_surface"]; got != "compat" {
+		t.Fatalf("allowed_surface = %#v, want %q", got, "compat")
+	}
+	if got := result[0]["bound_account_email"]; got != "bound@example.com" {
+		t.Fatalf("bound_account_email = %#v, want %q", got, "bound@example.com")
+	}
+	if _, ok := result[0]["total_cost"]; ok {
+		t.Fatalf("unexpected total_cost in user summary: %#v", result[0]["total_cost"])
+	}
+}
+
+func TestListUserTotalCosts_ReturnsRequestedTotals(t *testing.T) {
+	srv := newTestServer(t)
+
+	for _, user := range []*domain.User{
+		{ID: "u-1", Name: "alice", Status: "active", CreatedAt: time.Now().UTC()},
+		{ID: "u-2", Name: "bob", Status: "active", CreatedAt: time.Now().UTC()},
+		{ID: "u-3", Name: "carol", Status: "active", CreatedAt: time.Now().UTC()},
+	} {
+		if err := srv.store.CreateUser(context.Background(), user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, log := range []*domain.RequestLog{
+		{UserID: "u-1", Status: "ok", CostUSD: 1.25, CreatedAt: time.Now().UTC()},
+		{UserID: "u-1", Status: "ok", CostUSD: 0.75, CreatedAt: time.Now().UTC()},
+		{UserID: "u-2", Status: "ok", CostUSD: 2.50, CreatedAt: time.Now().UTC()},
+		{UserID: "u-3", Status: "upstream_403", CostUSD: 99, CreatedAt: time.Now().UTC()},
+	} {
+		if err := srv.store.InsertRequestLog(context.Background(), log); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleListUserTotalCosts(w, adminRequest("GET", "/admin/users/total-costs?ids=u-1,u-3"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+	if got := jsonPath(t, w.Body.Bytes(), "totals.u-1"); got != float64(2) {
+		t.Fatalf("totals.u-1 = %#v, want 2", got)
+	}
+	if got := jsonPath(t, w.Body.Bytes(), "totals.u-3"); got != float64(0) {
+		t.Fatalf("totals.u-3 = %#v, want 0", got)
+	}
+	var payload struct {
+		Totals map[string]float64 `json:"totals"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := payload.Totals["u-2"]; ok {
+		t.Fatalf("unexpected total for unrequested user u-2: %#v", payload.Totals["u-2"])
 	}
 }
 

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -973,6 +973,40 @@ func TestNativeRoute_RejectsCompatOnlyUser(t *testing.T) {
 	}
 }
 
+func TestHandleListModels_IncludesCodexGPT55(t *testing.T) {
+	srv := newTestServer(t)
+	srv.catalogDrivers = map[domain.Provider]driver.Descriptor{
+		domain.ProviderCodex: driver.NewCodexDriver(driver.CodexConfig{}),
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	srv.handleListModels(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Object string `json:"object"`
+		Data   []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if body.Object != "list" {
+		t.Fatalf("object = %q", body.Object)
+	}
+	for _, model := range body.Data {
+		if model.ID == "gpt-5.5" {
+			return
+		}
+	}
+	t.Fatalf("native models missing codex gpt-5.5: %#v", body.Data)
+}
+
 func TestDeleteUser_NotFound(t *testing.T) {
 	srv := newTestServer(t)
 

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -342,11 +342,11 @@ func TestListAccounts_IncludesSurfaceAvailability(t *testing.T) {
 	if got := byID["acct-native"]["available_native"]; got != true {
 		t.Fatalf("acct-native available_native = %#v, want true", got)
 	}
-	if got := byID["acct-native"]["available_compat"]; got != false {
-		t.Fatalf("acct-native available_compat = %#v, want false", got)
+	if got := byID["acct-native"]["available_compat"]; got != true {
+		t.Fatalf("acct-native available_compat = %#v, want true", got)
 	}
-	if got := byID["acct-compat"]["available_native"]; got != false {
-		t.Fatalf("acct-compat available_native = %#v, want false", got)
+	if got := byID["acct-compat"]["available_native"]; got != true {
+		t.Fatalf("acct-compat available_native = %#v, want true", got)
 	}
 	if got := byID["acct-compat"]["available_compat"]; got != true {
 		t.Fatalf("acct-compat available_compat = %#v, want true", got)

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -21,6 +21,24 @@ type DashboardResponse struct {
 	RecentFailures []*domain.RequestLog       `json:"recent_failures"`
 }
 
+type ActivityResponse struct {
+	Health         HealthInfo           `json:"health"`
+	Accounts       []ActivityAccountRef `json:"accounts"`
+	Users          []ActivityUserRef    `json:"users"`
+	Events         []DashboardEvent     `json:"events"`
+	RecentFailures []*domain.RequestLog `json:"recent_failures"`
+}
+
+type ActivityAccountRef struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type ActivityUserRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 type HealthInfo struct {
 	SQLite  string `json:"sqlite"`
 	Uptime  string `json:"uptime"`
@@ -73,7 +91,6 @@ type DashboardUser struct {
 	BoundAccountID    string         `json:"bound_account_id,omitempty"`
 	BoundAccountEmail string         `json:"bound_account_email,omitempty"`
 	LastActiveAt      *time.Time     `json:"last_active_at,omitempty"`
-	TotalCost         float64        `json:"total_cost"`
 }
 
 type DashboardEvent struct {
@@ -221,4 +238,8 @@ type UserDetailResponse struct {
 	Usage             []domain.UsagePeriod   `json:"usage"`
 	ModelUsage        []domain.ModelUsageRow `json:"model_usage"`
 	RecentRequests    []*domain.RequestLog   `json:"recent_requests"`
+}
+
+type UserTotalCostsResponse struct {
+	Totals map[string]float64 `json:"totals"`
 }

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -66,12 +66,15 @@ func (s *Server) registerAdminRoutes(mux *http.ServeMux) {
 
 	mux.Handle("POST /admin/users", admin(s.handleCreateUser))
 	mux.Handle("GET /admin/users", admin(s.handleListUsers))
+	mux.Handle("GET /admin/users/total-costs", admin(s.handleListUserTotalCosts))
 	mux.Handle("GET /admin/users/{id}", admin(s.handleGetUser))
 	mux.Handle("DELETE /admin/users/{id}", admin(s.handleDeleteUser))
 	mux.Handle("POST /admin/users/{id}/regenerate", admin(s.handleRegenerateUserToken))
 	mux.Handle("POST /admin/users/{id}/status", admin(s.handleUpdateUserStatus))
 	mux.Handle("POST /admin/users/{id}/policy", admin(s.handleUpdateUserPolicy))
 
+	mux.Handle("GET /admin/activity", admin(s.handleActivity))
+	mux.Handle("GET /admin/activity/usage", admin(s.handleActivityUsage))
 	mux.Handle("GET /admin/dashboard", admin(s.handleDashboard))
 	mux.Handle("GET /admin/health", admin(s.handleHealth))
 	mux.Handle("DELETE /admin/sessions/binding/{uuid}", admin(s.handleUnbindSession))

--- a/internal/store/mock_store.go
+++ b/internal/store/mock_store.go
@@ -629,7 +629,37 @@ func (m *MockStore) QueryUsagePeriods(_ context.Context, _ string, _ *time.Locat
 }
 
 func (m *MockStore) QueryUserTotalCosts(_ context.Context) (map[string]float64, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]float64)
+	for _, entry := range m.logs {
+		if entry.Status != "ok" {
+			continue
+		}
+		result[entry.UserID] += entry.CostUSD
+	}
+	return result, nil
+}
+
+func (m *MockStore) QueryUserTotalCostsByIDs(_ context.Context, userIDs []string) (map[string]float64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	allow := make(map[string]struct{}, len(userIDs))
+	result := make(map[string]float64, len(userIDs))
+	for _, userID := range userIDs {
+		allow[userID] = struct{}{}
+		result[userID] = 0
+	}
+	for _, entry := range m.logs {
+		if entry.Status != "ok" {
+			continue
+		}
+		if _, ok := allow[entry.UserID]; !ok {
+			continue
+		}
+		result[entry.UserID] += entry.CostUSD
+	}
+	return result, nil
 }
 
 func (m *MockStore) QueryModelUsage(_ context.Context, _ string) ([]domain.ModelUsageRow, error) {

--- a/internal/store/sqlite_logs.go
+++ b/internal/store/sqlite_logs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -256,24 +257,46 @@ func (s *SQLiteStore) QueryUsagePeriods(ctx context.Context, userID string, loc 
 		{"30 days", now.Add(-30 * 24 * time.Hour), now},
 	}
 
-	result := make([]domain.UsagePeriod, 0, len(periods))
+	baseArgs := make([]interface{}, 0, len(periods)*10+3)
+	selects := make([]string, 0, len(periods)*5)
 	for _, p := range periods {
-		var where string
-		var args []interface{}
-		if userID != "" {
-			where = "user_id = ? AND status = 'ok' AND created_at >= ? AND created_at < ?"
-			args = []interface{}{userID, p.since.Unix(), p.until.Unix()}
-		} else {
-			where = "status = 'ok' AND created_at >= ? AND created_at < ?"
-			args = []interface{}{p.since.Unix(), p.until.Unix()}
+		selects = append(selects,
+			"COUNT(CASE WHEN created_at >= ? AND created_at < ? THEN 1 END)",
+			"COALESCE(SUM(CASE WHEN created_at >= ? AND created_at < ? THEN input_tokens ELSE 0 END),0)",
+			"COALESCE(SUM(CASE WHEN created_at >= ? AND created_at < ? THEN output_tokens ELSE 0 END),0)",
+			"COALESCE(SUM(CASE WHEN created_at >= ? AND created_at < ? THEN cache_read_tokens ELSE 0 END),0)",
+			"COALESCE(SUM(CASE WHEN created_at >= ? AND created_at < ? THEN cost_usd ELSE 0 END),0)",
+		)
+		for i := 0; i < 5; i++ {
+			baseArgs = append(baseArgs, p.since.Unix(), p.until.Unix())
 		}
-		row := s.db.QueryRowContext(ctx, fmt.Sprintf(
-			`SELECT COALESCE(COUNT(*),0), COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
-			COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cost_usd),0)
-			FROM request_log WHERE %s`, where), args...)
-		up := domain.UsagePeriod{Label: p.label}
-		row.Scan(&up.Requests, &up.InputTokens, &up.OutputTokens, &up.CacheReadTokens, &up.CostUSD)
-		result = append(result, up)
+	}
+	where := "status = 'ok' AND created_at >= ? AND created_at < ?"
+	baseArgs = append(baseArgs, periods[len(periods)-1].since.Unix(), now.Unix())
+	if userID != "" {
+		where += " AND user_id = ?"
+		baseArgs = append(baseArgs, userID)
+	}
+
+	row := s.db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s FROM request_log WHERE %s", strings.Join(selects, ", "), where),
+		baseArgs...,
+	)
+
+	scanTargets := make([]interface{}, 0, len(periods)*5)
+	result := make([]domain.UsagePeriod, len(periods))
+	for i, p := range periods {
+		result[i].Label = p.label
+		scanTargets = append(scanTargets,
+			&result[i].Requests,
+			&result[i].InputTokens,
+			&result[i].OutputTokens,
+			&result[i].CacheReadTokens,
+			&result[i].CostUSD,
+		)
+	}
+	if err := row.Scan(scanTargets...); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -293,6 +316,45 @@ func (s *SQLiteStore) QueryUserTotalCosts(ctx context.Context) (map[string]float
 		result[userID] = cost
 	}
 	return result, rows.Err()
+}
+
+func (s *SQLiteStore) QueryUserTotalCostsByIDs(ctx context.Context, userIDs []string) (map[string]float64, error) {
+	result := make(map[string]float64, len(userIDs))
+	if len(userIDs) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(userIDs))
+	args := make([]interface{}, 0, len(userIDs))
+	for i, userID := range userIDs {
+		placeholders[i] = "?"
+		args = append(args, userID)
+		result[userID] = 0
+	}
+	query := fmt.Sprintf(
+		`SELECT user_id, COALESCE(SUM(cost_usd),0)
+		FROM request_log INDEXED BY idx_request_log_user
+		WHERE user_id IN (%s) AND status = 'ok'
+		GROUP BY user_id`,
+		strings.Join(placeholders, ","),
+	)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var userID string
+		var cost float64
+		if err := rows.Scan(&userID, &cost); err != nil {
+			return nil, err
+		}
+		result[userID] = cost
+	}
+	return result, rows.Err()
+}
+
+func strconvItoa(v int) string {
+	return strconv.Itoa(v)
 }
 
 func (s *SQLiteStore) QueryModelUsage(ctx context.Context, userID string) ([]domain.ModelUsageRow, error) {

--- a/internal/store/sqlite_logs_test.go
+++ b/internal/store/sqlite_logs_test.go
@@ -91,6 +91,45 @@ func TestLogAnalyticsIgnoreFailedAttempts(t *testing.T) {
 	}
 }
 
+func TestQueryUserTotalCostsByIDs(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "user-costs.db")
+	if err := Migrate(dbPath); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC()
+	for _, entry := range []*domain.RequestLog{
+		{UserID: "user-1", Status: "ok", CostUSD: 1.25, CreatedAt: now},
+		{UserID: "user-1", Status: "ok", CostUSD: 0.75, CreatedAt: now.Add(time.Second)},
+		{UserID: "user-2", Status: "ok", CostUSD: 2.50, CreatedAt: now.Add(2 * time.Second)},
+		{UserID: "user-3", Status: "upstream_403", CostUSD: 99, CreatedAt: now.Add(3 * time.Second)},
+	} {
+		if err := store.InsertRequestLog(context.Background(), entry); err != nil {
+			t.Fatalf("InsertRequestLog(%s): %v", entry.UserID, err)
+		}
+	}
+
+	totalCosts, err := store.QueryUserTotalCostsByIDs(context.Background(), []string{"user-1", "user-3"})
+	if err != nil {
+		t.Fatalf("QueryUserTotalCostsByIDs: %v", err)
+	}
+	if totalCosts["user-1"] != 2 {
+		t.Fatalf("totalCosts[user-1] = %v, want 2", totalCosts["user-1"])
+	}
+	if totalCosts["user-3"] != 0 {
+		t.Fatalf("totalCosts[user-3] = %v, want 0", totalCosts["user-3"])
+	}
+	if _, ok := totalCosts["user-2"]; ok {
+		t.Fatalf("unexpected total for user-2 = %v", totalCosts["user-2"])
+	}
+}
+
 func TestRequestLogObservabilityQueries(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "observability.db")
 	if err := Migrate(dbPath); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -71,5 +71,6 @@ type Store interface {
 	// Dashboard & analytics
 	QueryUsagePeriods(ctx context.Context, userID string, loc *time.Location) ([]domain.UsagePeriod, error)
 	QueryUserTotalCosts(ctx context.Context) (map[string]float64, error)
+	QueryUserTotalCostsByIDs(ctx context.Context, userIDs []string) (map[string]float64, error)
 	QueryModelUsage(ctx context.Context, userID string) ([]domain.ModelUsageRow, error)
 }

--- a/ops/systemd/local-cell-watchdog.service
+++ b/ops/systemd/local-cell-watchdog.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Self-heal broker local-danted cells
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Environment=BROKER_ENV_FILE=/etc/llm-broker.env
+Environment=WATCHDOG_IFACE=eth0
+ExecStart=/usr/local/bin/local-cell-watchdog
+

--- a/ops/systemd/local-cell-watchdog.timer
+++ b/ops/systemd/local-cell-watchdog.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run local-cell-watchdog every 2 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Unit=local-cell-watchdog.service
+
+[Install]
+WantedBy=timers.target
+

--- a/scripts/install-local-cell-watchdog.sh
+++ b/scripts/install-local-cell-watchdog.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+    echo "usage: $0 <ssh-target>" >&2
+    exit 1
+fi
+
+remote="$1"
+repo_root="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+cd "$repo_root"
+
+arch="$(ssh "$remote" 'uname -m')"
+case "$arch" in
+    x86_64|amd64) goarch="amd64" ;;
+    aarch64|arm64) goarch="arm64" ;;
+    *)
+        echo "unsupported remote arch: $arch" >&2
+        exit 1
+        ;;
+esac
+
+binary="$tmpdir/local-cell-watchdog"
+GOOS=linux GOARCH="$goarch" CGO_ENABLED=0 \
+    go build -o "$binary" ./cmd/local-cell-watchdog
+
+scp "$binary" \
+    "$repo_root/ops/systemd/local-cell-watchdog.service" \
+    "$repo_root/ops/systemd/local-cell-watchdog.timer" \
+    "$remote:/tmp/"
+
+ssh "$remote" '
+set -euo pipefail
+install -m 0755 /tmp/local-cell-watchdog /usr/local/bin/local-cell-watchdog
+install -m 0644 /tmp/local-cell-watchdog.service /etc/systemd/system/local-cell-watchdog.service
+install -m 0644 /tmp/local-cell-watchdog.timer /etc/systemd/system/local-cell-watchdog.timer
+systemctl daemon-reload
+systemctl enable --now local-cell-watchdog.timer
+systemctl start local-cell-watchdog.service
+systemctl status local-cell-watchdog.service --no-pager -l --lines=20 || true
+systemctl status local-cell-watchdog.timer --no-pager -l --lines=20 || true
+'

--- a/scripts/set-account-cell-lane.sh
+++ b/scripts/set-account-cell-lane.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+用法:
+  scripts/set-account-cell-lane.sh --remote <ssh_host> --account <email_or_id> --lane <unset|native|compat|all> [--allow-shared-cell] [--dry-run]
+
+说明:
+  - 实际修改的是“账号绑定 cell”的 labels.lane，不是账号字段。
+  - lane=compat  => 仅接 compat 请求
+  - lane=all     => 同时接 native / compat
+  - lane=unset   => 删除 lane，回到默认 native-only
+  - lane=native  => unset 的别名；脚本会直接删除 lane，而不是写回 native
+  - 默认拒绝修改共享 cell；若 cell 绑定了多个账号，需显式传 --allow-shared-cell
+
+示例:
+  scripts/set-account-cell-lane.sh --remote ccc --account kun --lane compat
+  scripts/set-account-cell-lane.sh --remote ccc --account kun --lane unset
+  scripts/set-account-cell-lane.sh --remote ccc --account kun --lane all
+  scripts/set-account-cell-lane.sh --remote ccc --account 2f7183ba-4398-446a-b5a7-b0b421bc3115 --lane unset
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "缺少命令: $1" >&2
+    exit 1
+  fi
+}
+
+REMOTE=""
+ACCOUNT=""
+LANE=""
+ALLOW_SHARED_CELL=0
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote)
+      REMOTE="${2:-}"
+      shift 2
+      ;;
+    --account)
+      ACCOUNT="${2:-}"
+      shift 2
+      ;;
+    --lane)
+      LANE="${2:-}"
+      shift 2
+      ;;
+    --allow-shared-cell)
+      ALLOW_SHARED_CELL=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "未知参数: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$REMOTE" || -z "$ACCOUNT" || -z "$LANE" ]]; then
+  usage >&2
+  exit 1
+fi
+
+LANE="$(printf '%s' "$LANE" | tr '[:upper:]' '[:lower:]')"
+case "$LANE" in
+  unset)
+    ;;
+  native)
+    LANE="unset"
+    ;;
+  compat|all)
+    ;;
+  *)
+    echo "--lane 只能是 unset、native、compat、all" >&2
+    exit 1
+    ;;
+esac
+
+require_cmd ssh
+
+ssh "$REMOTE" env TARGET_ACCOUNT="$ACCOUNT" TARGET_LANE="$LANE" ALLOW_SHARED_CELL="$ALLOW_SHARED_CELL" DRY_RUN="$DRY_RUN" bash -s <<'EOF'
+set -euo pipefail
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "远端缺少命令: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd python3
+require_cmd awk
+
+token="$(awk -F= '$1=="API_TOKEN"{print substr($0,index($0,"=")+1); exit}' /etc/llm-broker.env)"
+if [[ -z "$token" ]]; then
+  echo "远端 /etc/llm-broker.env 缺少 API_TOKEN" >&2
+  exit 1
+fi
+
+source /var/lib/llm-broker/bluegreen/layout.env
+active_slot="$(tr -d '\n' < /var/lib/llm-broker/bluegreen/active-slot)"
+case "$active_slot" in
+  blue)
+    port="$BLUE_PORT"
+    ;;
+  green)
+    port="$GREEN_PORT"
+    ;;
+  *)
+    echo "invalid active slot: $active_slot" >&2
+    exit 1
+    ;;
+esac
+
+accounts_json="$(mktemp)"
+cells_json="$(mktemp)"
+payload_json="$(mktemp)"
+verify_json="$(mktemp)"
+
+cleanup() {
+  rm -f "$accounts_json" "$cells_json" "$payload_json" "$verify_json"
+}
+trap cleanup EXIT
+
+curl -sS -H "x-api-key: $token" "http://127.0.0.1:${port}/admin/accounts" >"$accounts_json"
+curl -sS -H "x-api-key: $token" "http://127.0.0.1:${port}/admin/egress/cells" >"$cells_json"
+
+summary_json="$(
+  python3 - "$accounts_json" "$cells_json" "$TARGET_ACCOUNT" "$TARGET_LANE" "$ALLOW_SHARED_CELL" "$payload_json" <<'PY'
+import json
+import sys
+
+accounts_path, cells_path, target, target_lane, allow_shared_raw, payload_path = sys.argv[1:7]
+allow_shared = allow_shared_raw == "1"
+
+with open(accounts_path, "r", encoding="utf-8") as fh:
+    accounts = json.load(fh)
+with open(cells_path, "r", encoding="utf-8") as fh:
+    cells = json.load(fh)
+
+matches = [acct for acct in accounts if acct.get("email") == target or acct.get("id") == target]
+if not matches:
+    raise SystemExit(f"找不到账号: {target}")
+if len(matches) > 1:
+    raise SystemExit(f"账号匹配不唯一: {target}")
+
+acct = matches[0]
+cell_id = (acct.get("cell") or {}).get("id") or acct.get("cell_id") or ""
+if not cell_id:
+    raise SystemExit(f"账号 {acct.get('email') or acct.get('id')} 没有绑定 cell，不能切 lane")
+
+cell = next((item for item in cells if item.get("id") == cell_id), None)
+if cell is None:
+    raise SystemExit(f"找不到 cell: {cell_id}")
+
+cell_accounts = cell.get("accounts") or []
+if not any(item.get("id") == acct.get("id") for item in cell_accounts):
+    raise SystemExit(f"cell {cell_id} 的 accounts 列表里没有目标账号 {acct.get('id')}")
+if len(cell_accounts) > 1 and not allow_shared:
+    names = [item.get("email") or item.get("id") or "<unknown>" for item in cell_accounts]
+    raise SystemExit(
+        f"cell {cell_id} 当前绑定了多个账号: {', '.join(names)}；这是 cell 级切换，默认拒绝，请先拆分绑定或显式传 --allow-shared-cell"
+    )
+
+labels = dict(cell.get("labels") or {})
+old_lane = labels.get("lane") or "<unset>"
+if target_lane == "unset":
+    labels.pop("lane", None)
+    new_lane = "<unset>"
+else:
+    labels["lane"] = target_lane
+    new_lane = target_lane
+
+payload = {
+    "id": cell["id"],
+    "name": cell["name"],
+    "status": cell["status"],
+    "proxy": cell.get("proxy"),
+    "labels": labels,
+}
+
+with open(payload_path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, ensure_ascii=False, separators=(",", ":"))
+
+summary = {
+    "account_id": acct.get("id"),
+    "account_email": acct.get("email"),
+    "cell_id": cell_id,
+    "old_lane": old_lane,
+    "new_lane": new_lane,
+    "active_native_before": acct.get("available_native"),
+    "active_compat_before": acct.get("available_compat"),
+    "cell_accounts": [
+        {
+            "id": item.get("id"),
+            "email": item.get("email"),
+            "provider": item.get("provider"),
+        }
+        for item in cell_accounts
+    ],
+}
+print(json.dumps(summary, ensure_ascii=False))
+PY
+)"
+
+python3 - "$summary_json" "$active_slot" "$port" "$DRY_RUN" <<'PY'
+import json
+import sys
+
+summary = json.loads(sys.argv[1])
+active_slot = sys.argv[2]
+port = sys.argv[3]
+dry_run = sys.argv[4] == "1"
+
+print(f"active_slot={active_slot} port={port}")
+print(f"account={summary['account_email']} ({summary['account_id']})")
+print(f"cell={summary['cell_id']}")
+print(f"lane: {summary['old_lane']} -> {summary['new_lane']}")
+print(
+    f"before: native={summary['active_native_before']} compat={summary['active_compat_before']}"
+)
+if len(summary["cell_accounts"]) > 1:
+    joined = ", ".join(
+        f"{item['email']}[{item['provider']}]"
+        for item in summary["cell_accounts"]
+    )
+    print(f"shared_cell_accounts={joined}")
+if dry_run:
+    print("dry_run=true")
+PY
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  exit 0
+fi
+
+response_json="$(
+  curl -sS -X POST \
+    -H "x-api-key: $token" \
+    -H "Content-Type: application/json" \
+    --data @"$payload_json" \
+    "http://127.0.0.1:${port}/admin/egress/cells"
+)"
+
+curl -sS -H "x-api-key: $token" "http://127.0.0.1:${port}/admin/accounts" >"$verify_json"
+
+python3 - "$response_json" "$verify_json" "$TARGET_ACCOUNT" <<'PY'
+import json
+import sys
+
+response = json.loads(sys.argv[1])
+with open(sys.argv[2], "r", encoding="utf-8") as fh:
+    accounts = json.load(fh)
+target = sys.argv[3]
+
+acct = next((item for item in accounts if item.get("email") == target or item.get("id") == target), None)
+if acct is None:
+    raise SystemExit(f"写入后找不到目标账号: {target}")
+
+lane = (response.get("labels") or {}).get("lane") or "<unset>"
+print(f"applied_lane={lane}")
+print(
+    "after: "
+    f"native={acct.get('available_native')} "
+    f"compat={acct.get('available_compat')} "
+    f"cell_id={acct.get('cell_id') or '<none>'}"
+)
+PY
+EOF

--- a/web/src/lib/admin-types.ts
+++ b/web/src/lib/admin-types.ts
@@ -32,7 +32,10 @@ export interface UserSummary {
 	bound_account_id?: string;
 	bound_account_email?: string;
 	last_active_at: string | null;
-	total_cost: number;
+}
+
+export interface UserTotalCostsResponse {
+	totals: Record<string, number>;
 }
 
 export interface DashboardEvent {
@@ -150,6 +153,24 @@ export interface DashboardData {
 	events: DashboardEvent[];
 	outcome_stats: RelayOutcomeStat[];
 	cell_risk: CellRiskStat[];
+	recent_failures: RecentRequestLog[];
+}
+
+export interface ActivityAccountRef {
+	id: string;
+	email: string;
+}
+
+export interface ActivityUserRef {
+	id: string;
+	name: string;
+}
+
+export interface ActivityData {
+	health: HealthInfo;
+	accounts: ActivityAccountRef[];
+	users: ActivityUserRef[];
+	events: DashboardEvent[];
 	recent_failures: RecentRequestLog[];
 }
 

--- a/web/src/routes/activity/+page.svelte
+++ b/web/src/routes/activity/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { api } from '$lib/api';
-	import type { DashboardData, DashboardEvent, RecentRequestLog } from '$lib/admin-types';
+	import type { ActivityData, DashboardEvent, RecentRequestLog, UsagePeriod } from '$lib/admin-types';
 	import ConfirmAction from '$lib/components/ConfirmAction.svelte';
 	import { eventTypeColor, fmtCost, fmtDate, fmtJSON, fmtNum, fmtTime, shortModel, statusColor } from '$lib/format';
 
-	let data = $state<DashboardData | null>(null);
+	let data = $state<ActivityData | null>(null);
+	let usage = $state<UsagePeriod[]>([]);
 	let error = $state('');
+	let usageError = $state('');
+	let usageLoading = $state(false);
 	let lastRefresh = $state('');
 
 	$effect(() => {
@@ -14,11 +17,27 @@
 
 	async function loadAll() {
 		error = '';
+		usageError = '';
 		try {
-			data = await api<DashboardData>('/dashboard');
+			data = await api<ActivityData>('/activity');
+			void loadUsage();
 			lastRefresh = new Date().toLocaleTimeString('en-GB', { hour12: false });
 		} catch (e: any) {
 			error = e.message;
+		}
+	}
+
+	async function loadUsage() {
+		usageLoading = true;
+		try {
+			// Remote SQLite analytics can still exceed the default 15s fetch timeout.
+			// Remove this override after indexed/preaggregated usage queries are consistently <15s.
+			usage = await api<UsagePeriod[]>('/activity/usage', { timeout: 30000 });
+		} catch (e: any) {
+			usage = [];
+			usageError = e.message;
+		} finally {
+			usageLoading = false;
 		}
 	}
 
@@ -107,7 +126,11 @@
 	<div class="sub">{data.health.version} &middot; up {data.health.uptime} &middot; sqlite <span class={data.health.sqlite === 'ok' ? 'g' : 'r'}>{data.health.sqlite}</span></div>
 
 	<h2>usage</h2>
-	{#if data.usage.length === 0}
+	{#if usageLoading}
+		<p class="muted">loading usage...</p>
+	{:else if usageError}
+		<p class="error-msg">{usageError}</p>
+	{:else if usage.length === 0}
 		<p class="muted">no usage data yet</p>
 	{:else}
 		<table>
@@ -122,14 +145,14 @@
 				</tr>
 			</thead>
 			<tbody>
-				{#each data.usage as usage, i (usage.label)}
+				{#each usage as period, i (period.label)}
 					<tr>
-						<td>{usage.label}</td>
-						<td class="num">{fmtNum(usage.requests)}</td>
-						<td class="num">{fmtNum(usage.input_tokens)}</td>
-						<td class="num">{fmtNum(usage.output_tokens)}</td>
-						<td class="num">{fmtNum(usage.cache_read_tokens)}</td>
-						<td class="num">{#if i === data.usage.length - 1}<b>{fmtCost(usage.cost_usd)}</b>{:else}{fmtCost(usage.cost_usd)}{/if}</td>
+						<td>{period.label}</td>
+						<td class="num">{fmtNum(period.requests)}</td>
+						<td class="num">{fmtNum(period.input_tokens)}</td>
+						<td class="num">{fmtNum(period.output_tokens)}</td>
+						<td class="num">{fmtNum(period.cache_read_tokens)}</td>
+						<td class="num">{#if i === usage.length - 1}<b>{fmtCost(period.cost_usd)}</b>{:else}{fmtCost(period.cost_usd)}{/if}</td>
 					</tr>
 				{/each}
 			</tbody>

--- a/web/src/routes/users/+page.svelte
+++ b/web/src/routes/users/+page.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { api } from '$lib/api';
-	import type { AccountListItem, DashboardData, UserSummary, UserSurface } from '$lib/admin-types';
+	import type { AccountListItem, UserSummary, UserSurface, UserTotalCostsResponse } from '$lib/admin-types';
 	import { dotClass, fmtCost, timeAgo } from '$lib/format';
 
 	let users = $state<UserSummary[]>([]);
 	let accounts = $state<AccountListItem[]>([]);
+	let totalCosts = $state<Record<string, number>>({});
 	let error = $state('');
 	let lastRefresh = $state('');
+	let loadingTotalCosts = $state(false);
+	let totalCostRequestSeq = 0;
 
 	let showAddUser = $state(false);
 	let newUserName = $state('');
@@ -25,15 +28,41 @@
 	async function loadAll() {
 		error = '';
 		try {
-			const [dashboard, accountList] = await Promise.all([
-				api<DashboardData>('/dashboard'),
+			const [userList, accountList] = await Promise.all([
+				api<UserSummary[]>('/users'),
 				api<AccountListItem[]>('/accounts').catch(() => [])
 			]);
-			users = dashboard.users;
+			users = userList;
 			accounts = [...accountList].sort((a, b) => a.email.localeCompare(b.email));
+			void loadUserTotalCosts(userList.map((user) => user.id));
 			lastRefresh = new Date().toLocaleTimeString('en-GB', { hour12: false });
 		} catch (e: any) {
 			error = e.message;
+		}
+	}
+
+	async function loadUserTotalCosts(userIDs: string[]) {
+		const requestSeq = ++totalCostRequestSeq;
+		if (userIDs.length === 0) {
+			totalCosts = {};
+			loadingTotalCosts = false;
+			return;
+		}
+		loadingTotalCosts = true;
+		try {
+			const params = new URLSearchParams({ ids: userIDs.join(',') });
+			// Remote SQLite analytics can still exceed the default 15s fetch timeout.
+			// Remove this override after indexed/preaggregated user-cost queries are consistently <15s.
+			const result = await api<UserTotalCostsResponse>(`/users/total-costs?${params.toString()}`, { timeout: 30000 });
+			if (requestSeq !== totalCostRequestSeq) return;
+			totalCosts = result.totals;
+		} catch {
+			if (requestSeq !== totalCostRequestSeq) return;
+			totalCosts = {};
+		} finally {
+			if (requestSeq === totalCostRequestSeq) {
+				loadingTotalCosts = false;
+			}
 		}
 	}
 
@@ -96,11 +125,11 @@
 					allowed_surface: res.allowed_surface,
 					bound_account_id: res.bound_account_id,
 					bound_account_email: res.bound_account_email,
-					last_active_at: null,
-					total_cost: 0
+					last_active_at: null
 				},
 				...users
 			];
+			void loadUserTotalCosts(users.map((user) => user.id));
 			showAddUser = false;
 			newUserName = '';
 			newAllowedSurface = 'native';
@@ -127,6 +156,17 @@ curl -fsS "$BASE_URL/v1/models" \\
 		await navigator.clipboard.writeText(buildKeyCheckCmd(createdUser.token));
 		copied = true;
 		setTimeout(() => { copied = false; }, 2000);
+	}
+
+	function hasTotalCost(userID: string): boolean {
+		return Object.prototype.hasOwnProperty.call(totalCosts, userID);
+	}
+
+	function totalCostText(userID: string): string {
+		if (hasTotalCost(userID)) {
+			return fmtCost(totalCosts[userID] ?? 0);
+		}
+		return loadingTotalCosts ? '...' : '-';
 	}
 </script>
 
@@ -200,7 +240,7 @@ curl -fsS "$BASE_URL/v1/models" \\
 						<td>{user.allowed_surface}</td>
 						<td class:muted={!user.bound_account_id}>{boundAccountText(user)}</td>
 						<td>{timeAgo(user.last_active_at ?? '')}</td>
-						<td class="num {user.total_cost === 0 ? 'muted' : ''}">{fmtCost(user.total_cost)}</td>
+						<td class="num {hasTotalCost(user.id) && (totalCosts[user.id] ?? 0) === 0 ? 'muted' : ''}">{totalCostText(user.id)}</td>
 					</tr>
 				{/each}
 			</tbody>


### PR DESCRIPTION
## Summary

This PR ships the emergency workaround from #25 so `claude` compat traffic can recover immediately on `ccc`.

Changes:
- allow `claude` accounts to serve `compat` even when they are legacy-direct / not bound to a cell
- ignore global `bound_account_id` when it points to a different provider
- update pool / contract tests for the hotfix behavior

## Why

The current failure mode is not that Claude accounts lack compat capability.
The real problem is that compat eligibility is incorrectly coupled to `cell.labels.lane`, so legacy-direct Claude accounts are excluded from the compat pool.

That coupling caused `503 no available accounts` on `ccc`, and after recovery the broker-side compat concurrency limiter became the next bottleneck.

## Scope

This is an emergency workaround only.
It is intentionally narrow and does **not** fix the root design problem.

What it does **not** solve:
- `users.bound_account_id` is still global instead of provider-scoped
- sticky routing is still modeled per `(user, provider, surface)` instead of per `(user, provider)`
- compat surface policy is still not fully separated from transport routing at the architecture level

## Follow-up

The full fix remains tracked in:
- Refs #25

Do not close #25 from this PR. The long-term fix still needs:
- provider-scoped account pinning
- provider-scoped sticky routing
- complete removal of compat/account eligibility from cell lane semantics

## Verification

- `go test ./...`
- deployed to `ccc` via blue-green
- verified both Claude accounts are now `available_compat=true`
- verified broker-side compat concurrency limit was later raised on `ccc` from 4 to 8 to reduce `429 rate_limit_error`
