### PR TITLE
Fix egress cell deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ Main endpoints:
 | `GET` | `/admin/accounts/{id}` | account detail |
 | `POST` | `/admin/accounts/{id}/refresh` | refresh token |
 | `POST` | `/admin/accounts/{id}/test` | probe account |
+| `POST` | `/admin/accounts/{id}/cell` | bind or unbind an account egress cell |
+| `GET` | `/admin/egress/cells` | list egress cells and bound accounts |
+| `POST` | `/admin/egress/cells` | create or update an egress cell |
+| `DELETE` | `/admin/egress/cells/{id}` | delete an unbound egress cell |
+| `POST` | `/admin/egress/cells/{id}/test` | test an egress cell proxy |
+| `POST` | `/admin/egress/cells/{id}/clear-cooldown` | clear an egress cell cooldown |
 | `GET` | `/admin/dashboard` | dashboard data |
 | `GET` | `/admin/users` | list users |
 | `POST` | `/admin/users` | create user key |

--- a/docs/egress-cell-operations.md
+++ b/docs/egress-cell-operations.md
@@ -1,0 +1,72 @@
+# Egress Cell Operations
+
+## Invariant
+
+- stable axis: `accounts.cell_id` is the account-to-egress-cell binding.
+- change axis: cells can be created, updated, unbound from accounts, then deleted.
+- invariant: a cell can be deleted only when no account is bound to its canonical ID.
+
+Canonical `cell_id` means leading and trailing whitespace is not semantic. Old dirty account rows such as `" cell-http "` still refer to `cell-http`.
+
+## Delete Cell
+
+Use the admin API:
+
+```bash
+curl -X DELETE "$BASE_URL/admin/egress/cells/$CELL_ID" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+Expected responses:
+
+- `200`: the cell existed and was deleted.
+- `404`: the cell does not exist.
+- `409`: at least one account is still bound to the cell.
+
+The UI exposes the same operation on the cell detail page:
+
+```text
+/cells/{id}
+```
+
+The delete action is shown only when the current cell list projection reports zero bound accounts. The backend remains the source of truth; if an account is rebound after the page loads, the DELETE request returns `409` and the cell is kept.
+
+## Unbind First
+
+Before deleting a bound cell, move each account to another cell or to legacy direct:
+
+```bash
+curl -X POST "$BASE_URL/admin/accounts/$ACCOUNT_ID/cell" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cell_id":""}'
+```
+
+Then rerun:
+
+```bash
+curl "$BASE_URL/admin/egress/cells" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+Only delete after the target cell has an empty `accounts` array.
+
+## Boundary
+
+Do not delete cells by editing SQLite directly. The active process owns the in-memory pool projection, and blue/green deployments make direct DB writes ambiguous. Use the admin API so the pool, store, dashboard projection, and cell detail page share one state transition.
+
+Do not treat whitespace variants as separate cells. The pool canonicalizes account `cell_id` values for binding validation, delete protection, and account/cell list projection.
+
+## Verification
+
+For this feature, the regression boundary is:
+
+```bash
+go test ./internal/pool ./internal/server -run 'Test(DeleteCell|DeleteEgressCell|BindAccountCell|ListEgressCells|CreateExchangedAccount|UpdateExchangedAccount)' -count=1
+go test ./... -count=1
+go test -race ./internal/pool ./internal/server -run 'Test(BindAccountCell|Update_RejectsCellDeletedAfterPreflight|Add_RejectsCellDeletedAfterPreflight)' -count=1
+go build ./...
+go vet ./...
+cd web && npm run build
+git diff --check HEAD^..HEAD
+```

--- a/internal/pool/pool_accounts.go
+++ b/internal/pool/pool_accounts.go
@@ -70,11 +70,21 @@ func (p *Pool) Update(accountID string, fn func(*domain.Account)) error {
 	}
 	acct, ok := p.accounts[accountID]
 	if !ok {
-		return fmt.Errorf("account %s not found", accountID)
+		return ErrAccountNotFound
 	}
 
 	projected := p.projectAccountLocked(acct)
 	fn(projected)
+	projected.CellID = canonicalCellID(projected.CellID)
+	if projected.CellID != acct.CellID || projected.Provider != acct.Provider {
+		currentCellID := acct.CellID
+		if projected.Provider != acct.Provider {
+			currentCellID = ""
+		}
+		if err := p.validateCellBindingLocked(accountID, projected.Provider, currentCellID, projected.CellID, time.Now().UTC()); err != nil {
+			return err
+		}
+	}
 
 	acct.Email = projected.Email
 	acct.Provider = projected.Provider
@@ -120,6 +130,10 @@ func (p *Pool) Add(acct *domain.Account) error {
 	stateJSON := acct.ProviderStateJSON
 	if stateJSON == "" {
 		stateJSON = "{}"
+	}
+	acct.CellID = canonicalCellID(acct.CellID)
+	if err := p.validateCellBindingLocked(acct.ID, acct.Provider, "", acct.CellID, time.Now().UTC()); err != nil {
+		return err
 	}
 	p.refreshBucketKeyLocked(acct, stateJSON)
 	bucket := p.ensureBucketLocked(acct)

--- a/internal/pool/pool_buckets.go
+++ b/internal/pool/pool_buckets.go
@@ -134,6 +134,7 @@ func (p *Pool) ensureBucketLocked(acct *domain.Account) *domain.QuotaBucket {
 
 func (p *Pool) projectAccountLocked(acct *domain.Account) *domain.Account {
 	copy := *acct
+	copy.CellID = canonicalCellID(copy.CellID)
 	copy.BucketKey = p.bucketKeyLocked(acct)
 	copy.CooldownUntil = nil
 	copy.ProviderStateJSON = "{}"

--- a/internal/pool/pool_cells.go
+++ b/internal/pool/pool_cells.go
@@ -2,8 +2,10 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/yansircc/llm-broker/internal/domain"
@@ -39,7 +41,22 @@ func cloneCell(src *domain.EgressCell) *domain.EgressCell {
 	return &copy
 }
 
+var (
+	ErrCellNotFound    = errors.New("cell not found")
+	ErrCellInUse       = errors.New("cell has bound accounts")
+	ErrCellInactive    = errors.New("cell is not active")
+	ErrCellCoolingDown = errors.New("cell is cooling down")
+	ErrCellNoProxy     = errors.New("cell has no usable proxy")
+	ErrCellOccupied    = errors.New("cell is already bound to another account of the same provider")
+	ErrAccountNotFound = errors.New("account not found")
+)
+
+func canonicalCellID(cellID string) string {
+	return strings.TrimSpace(cellID)
+}
+
 func (p *Pool) cellLocked(cellID string) *domain.EgressCell {
+	cellID = canonicalCellID(cellID)
 	if cellID == "" {
 		return nil
 	}
@@ -47,7 +64,7 @@ func (p *Pool) cellLocked(cellID string) *domain.EgressCell {
 }
 
 func (p *Pool) cellForAccountLocked(acct *domain.Account) *domain.EgressCell {
-	if acct == nil || acct.CellID == "" {
+	if acct == nil || canonicalCellID(acct.CellID) == "" {
 		return nil
 	}
 	return p.cellLocked(acct.CellID)
@@ -117,6 +134,120 @@ func (p *Pool) SaveCell(cell *domain.EgressCell) error {
 	}
 	copy.HydrateRuntime()
 	p.cells[copy.ID] = copy
+	return nil
+}
+
+func (p *Pool) BindAccountCell(accountID, cellID string, now time.Time) error {
+	cellID = canonicalCellID(cellID)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.reloadStateLocked(context.Background()); err != nil {
+		return fmt.Errorf("refresh pool state: %w", err)
+	}
+	acct, ok := p.accounts[accountID]
+	if !ok {
+		return ErrAccountNotFound
+	}
+	if err := p.validateCellBindingLocked(accountID, acct.Provider, acct.CellID, cellID, now); err != nil {
+		return err
+	}
+	acct.CellID = cellID
+	p.persistLocked(acct)
+	return nil
+}
+
+func (p *Pool) DeleteCell(cellID string) error {
+	cellID = canonicalCellID(cellID)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.reloadStateLocked(context.Background()); err != nil {
+		return fmt.Errorf("refresh pool state: %w", err)
+	}
+	if p.cellLocked(cellID) == nil {
+		return ErrCellNotFound
+	}
+	for _, acct := range p.accounts {
+		if canonicalCellID(acct.CellID) == cellID {
+			return ErrCellInUse
+		}
+	}
+	if err := p.store.DeleteEgressCell(context.Background(), cellID); err != nil {
+		return err
+	}
+	delete(p.cells, cellID)
+	return nil
+}
+
+func (p *Pool) GetBindableCell(cellID string, now time.Time) (*domain.EgressCell, error) {
+	cellID = canonicalCellID(cellID)
+	if cellID == "" {
+		return nil, ErrCellNotFound
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.reloadStateLocked(context.Background()); err != nil {
+		return nil, fmt.Errorf("refresh pool state: %w", err)
+	}
+	cell := p.cellLocked(cellID)
+	if err := bindableCellError(cell, now); err != nil {
+		return nil, err
+	}
+	return cloneCell(cell), nil
+}
+
+func (p *Pool) ValidateCellBinding(accountID string, provider domain.Provider, currentCellID, requestedCellID string, now time.Time) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.reloadStateLocked(context.Background()); err != nil {
+		return fmt.Errorf("refresh pool state: %w", err)
+	}
+	return p.validateCellBindingLocked(accountID, provider, currentCellID, requestedCellID, now)
+}
+
+func (p *Pool) validateCellBindingLocked(accountID string, provider domain.Provider, currentCellID, requestedCellID string, now time.Time) error {
+	currentCellID = canonicalCellID(currentCellID)
+	requestedCellID = canonicalCellID(requestedCellID)
+	if requestedCellID == "" || requestedCellID == currentCellID {
+		return nil
+	}
+
+	cell := p.cellLocked(requestedCellID)
+	if err := bindableCellError(cell, now); err != nil {
+		return err
+	}
+	if cell.Proxy == nil || cell.Proxy.Type != "socks5" {
+		for _, acct := range p.accounts {
+			if acct == nil || acct.ID == accountID {
+				continue
+			}
+			if canonicalCellID(acct.CellID) == requestedCellID && acct.Provider == provider {
+				return ErrCellOccupied
+			}
+		}
+	}
+	return nil
+}
+
+func bindableCellError(cell *domain.EgressCell, now time.Time) error {
+	if cell == nil {
+		return ErrCellNotFound
+	}
+	status := cell.Status
+	if status == "" {
+		status = domain.EgressCellActive
+	}
+	if status != domain.EgressCellActive {
+		return ErrCellInactive
+	}
+	if cell.CooldownUntil != nil && now.Before(*cell.CooldownUntil) {
+		return ErrCellCoolingDown
+	}
+	if cell.Proxy == nil || strings.TrimSpace(cell.Proxy.Host) == "" || cell.Proxy.Port <= 0 {
+		return ErrCellNoProxy
+	}
 	return nil
 }
 

--- a/internal/pool/pool_schedule.go
+++ b/internal/pool/pool_schedule.go
@@ -18,7 +18,7 @@ func (p *Pool) isAvailable(acct *domain.Account, drv driver.SchedulerDriver, mod
 	if acct.Status != domain.StatusActive {
 		return false
 	}
-	if acct.CellID != "" && !p.cellAvailableLocked(p.cellForAccountLocked(acct), now) {
+	if canonicalCellID(acct.CellID) != "" && !p.cellAvailableLocked(p.cellForAccountLocked(acct), now) {
 		return false
 	}
 	if cooldownUntil := p.bucketCooldownLocked(acct); cooldownUntil != nil && now.Before(*cooldownUntil) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"math/rand"
 	"net/http"
@@ -258,7 +259,9 @@ func TestPickForSurface_ClaudeIgnoresCellLanes(t *testing.T) {
 		}
 	}
 
-	gotNative, err := p.PickForSurface(testDriver, nil, "claude-haiku", "", domain.SurfaceNative)
+	exclusions := []Exclusion{ExcludeAccount("native")}
+
+	gotNative, err := p.PickForSurface(testDriver, exclusions, "claude-haiku", "", domain.SurfaceNative)
 	if err != nil {
 		t.Fatalf("PickForSurface(native): %v", err)
 	}
@@ -266,7 +269,7 @@ func TestPickForSurface_ClaudeIgnoresCellLanes(t *testing.T) {
 		t.Fatalf("PickForSurface(native) = %s, want compat", gotNative.ID)
 	}
 
-	gotCompat, err := p.PickForSurface(testDriver, nil, "claude-haiku", "", domain.SurfaceCompat)
+	gotCompat, err := p.PickForSurface(testDriver, exclusions, "claude-haiku", "", domain.SurfaceCompat)
 	if err != nil {
 		t.Fatalf("PickForSurface(compat): %v", err)
 	}
@@ -447,6 +450,265 @@ func TestClearCellCooldown(t *testing.T) {
 	}
 	if cell.CooldownUntil != nil {
 		t.Fatalf("cell cooldown = %v, want nil", cell.CooldownUntil)
+	}
+}
+
+func TestDeleteCell_RemovesUnboundCell(t *testing.T) {
+	p := newTestPool(t)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-a",
+		Name:      "cell-a",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-a): %v", err)
+	}
+
+	if err := p.DeleteCell("cell-a"); err != nil {
+		t.Fatalf("DeleteCell(cell-a): %v", err)
+	}
+	if cell := p.GetCell("cell-a"); cell != nil {
+		t.Fatalf("GetCell(cell-a) = %#v, want nil", cell)
+	}
+}
+
+func TestDeleteCell_RejectsBoundCell(t *testing.T) {
+	acct := activeAccount("acct-a", "acct-a@example.com")
+	acct.CellID = "cell-a"
+
+	p := newTestPool(t, acct)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-a",
+		Name:      "cell-a",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-a): %v", err)
+	}
+
+	if err := p.DeleteCell("cell-a"); !errors.Is(err, ErrCellInUse) {
+		t.Fatalf("DeleteCell(cell-a) = %v, want %v", err, ErrCellInUse)
+	}
+	if cell := p.GetCell("cell-a"); cell == nil {
+		t.Fatal("bound cell should remain")
+	}
+	if got := p.Get("acct-a"); got == nil || got.CellID != "cell-a" {
+		t.Fatalf("account cell_id = %#v, want cell-a", got)
+	}
+}
+
+func TestUpdate_TrimsCellIDBeforePersisting(t *testing.T) {
+	acct := activeAccount("acct-a", "acct-a@example.com")
+	p := newTestPool(t, acct)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-trim",
+		Name:      "cell-trim",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-trim): %v", err)
+	}
+
+	if err := p.Update("acct-a", func(a *domain.Account) {
+		a.CellID = " cell-trim "
+	}); err != nil {
+		t.Fatalf("Update(cell_id): %v", err)
+	}
+	if got := p.Get("acct-a"); got == nil || got.CellID != "cell-trim" {
+		t.Fatalf("account cell_id = %#v, want cell-trim", got)
+	}
+	if err := p.DeleteCell("cell-trim"); !errors.Is(err, ErrCellInUse) {
+		t.Fatalf("DeleteCell(cell-trim) = %v, want %v", err, ErrCellInUse)
+	}
+}
+
+func TestAdd_TrimsCellIDBeforePersisting(t *testing.T) {
+	p := newTestPool(t)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-trim",
+		Name:      "cell-trim",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-trim): %v", err)
+	}
+
+	acct := activeAccount("acct-new", "new@example.com")
+	acct.CellID = " cell-trim "
+	if err := p.Add(acct); err != nil {
+		t.Fatalf("Add(): %v", err)
+	}
+	if got := p.Get("acct-new"); got == nil || got.CellID != "cell-trim" {
+		t.Fatalf("account cell_id = %#v, want cell-trim", got)
+	}
+	if err := p.DeleteCell("cell-trim"); !errors.Is(err, ErrCellInUse) {
+		t.Fatalf("DeleteCell(cell-trim) = %v, want %v", err, ErrCellInUse)
+	}
+}
+
+func TestUpdate_RevalidatesOccupiedCellWhenProviderChanges(t *testing.T) {
+	owner := activeAccount("acct-owner", "owner@example.com")
+	owner.CellID = "cell-http"
+	other := &domain.Account{
+		ID:       "acct-other",
+		Email:    "other@example.com",
+		Provider: domain.ProviderGemini,
+		Subject:  "acct-other",
+		Status:   domain.StatusActive,
+		Priority: 50,
+		CellID:   "cell-http",
+	}
+
+	p := newTestPool(t, owner, other)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-http",
+		Name:      "cell-http",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "http", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-http): %v", err)
+	}
+
+	err := p.Update("acct-other", func(a *domain.Account) {
+		a.Provider = domain.ProviderClaude
+	})
+	if !errors.Is(err, ErrCellOccupied) {
+		t.Fatalf("Update(provider) = %v, want %v", err, ErrCellOccupied)
+	}
+	if got := p.Get("acct-other"); got == nil || got.Provider != domain.ProviderGemini || got.CellID != "cell-http" {
+		t.Fatalf("account after failed provider update = %#v", got)
+	}
+}
+
+func TestValidateCellBinding_CanonicalizesExistingCellOccupancy(t *testing.T) {
+	owner := activeAccount("acct-owner", "owner@example.com")
+	owner.CellID = " cell-http "
+	other := activeAccount("acct-other", "other@example.com")
+
+	p := newTestPool(t, owner, other)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-http",
+		Name:      "cell-http",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "http", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-http): %v", err)
+	}
+
+	err := p.BindAccountCell("acct-other", "cell-http", time.Now().UTC())
+	if !errors.Is(err, ErrCellOccupied) {
+		t.Fatalf("BindAccountCell() = %v, want %v", err, ErrCellOccupied)
+	}
+	if got := p.Get("acct-owner"); got == nil || got.CellID != "cell-http" || got.Cell == nil || got.Cell.ID != "cell-http" {
+		t.Fatalf("projected dirty owner = %#v, want canonical cell-http with cell projection", got)
+	}
+	if err := p.DeleteCell("cell-http"); !errors.Is(err, ErrCellInUse) {
+		t.Fatalf("DeleteCell(cell-http) = %v, want %v", err, ErrCellInUse)
+	}
+}
+
+func TestBindAccountCell_RejectsCellDeletedAfterPreflight(t *testing.T) {
+	acct := activeAccount("acct-a", "acct-a@example.com")
+	p := newTestPool(t, acct)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell-race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-race): %v", err)
+	}
+
+	if cell := p.GetCell("cell-race"); cell == nil {
+		t.Fatal("preflight expected cell-race to exist")
+	}
+	if err := p.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	err := p.BindAccountCell("acct-a", "cell-race", time.Now().UTC())
+	if !errors.Is(err, ErrCellNotFound) {
+		t.Fatalf("BindAccountCell() = %v, want %v", err, ErrCellNotFound)
+	}
+	if got := p.Get("acct-a"); got == nil || got.CellID != "" {
+		t.Fatalf("account cell_id = %#v, want empty", got)
+	}
+}
+
+func TestUpdate_RejectsCellDeletedAfterPreflight(t *testing.T) {
+	acct := activeAccount("acct-a", "acct-a@example.com")
+	p := newTestPool(t, acct)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell-race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-race): %v", err)
+	}
+
+	if cell := p.GetCell("cell-race"); cell == nil {
+		t.Fatal("preflight expected cell-race to exist")
+	}
+	if err := p.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	err := p.Update("acct-a", func(a *domain.Account) {
+		a.CellID = "cell-race"
+	})
+	if !errors.Is(err, ErrCellNotFound) {
+		t.Fatalf("Update() = %v, want %v", err, ErrCellNotFound)
+	}
+	if got := p.Get("acct-a"); got == nil || got.CellID != "" {
+		t.Fatalf("account cell_id = %#v, want empty", got)
+	}
+}
+
+func TestAdd_RejectsCellDeletedAfterPreflight(t *testing.T) {
+	p := newTestPool(t)
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell-race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell(cell-race): %v", err)
+	}
+
+	if cell := p.GetCell("cell-race"); cell == nil {
+		t.Fatal("preflight expected cell-race to exist")
+	}
+	if err := p.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	acct := activeAccount("acct-new", "new@example.com")
+	acct.CellID = "cell-race"
+	err := p.Add(acct)
+	if !errors.Is(err, ErrCellNotFound) {
+		t.Fatalf("Add() = %v, want %v", err, ErrCellNotFound)
+	}
+	if got := p.Get("acct-new"); got != nil {
+		t.Fatalf("Get(acct-new) = %#v, want nil", got)
 	}
 }
 

--- a/internal/server/admin_accounts.go
+++ b/internal/server/admin_accounts.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/yansircc/llm-broker/internal/domain"
+	"github.com/yansircc/llm-broker/internal/pool"
 )
 
 // handleListAccounts returns all accounts (without tokens).
@@ -29,10 +31,10 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 			WeightMode:      a.PriorityMode,
 			LastUsedAt:      a.LastUsedAt,
 			CooldownUntil:   a.CooldownUntil,
-			CellID:          a.CellID,
+			CellID:          canonicalCellID(a.CellID),
 			AvailableNative: avail.Native,
 			AvailableCompat: avail.Compat,
-			Cell:            toCellSummary(a.Cell, cellCounts[a.CellID]),
+			Cell:            toCellSummary(a.Cell, cellCounts[canonicalCellID(a.CellID)]),
 			Windows:         proj.windows,
 		})
 	}
@@ -102,8 +104,8 @@ func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 		LastRefreshAt:  acct.LastRefreshAt,
 		ExpiresAt:      acct.ExpiresAt,
 		CooldownUntil:  acct.CooldownUntil,
-		CellID:         acct.CellID,
-		Cell:           toCellSummary(acct.Cell, cellCounts[acct.CellID]),
+		CellID:         canonicalCellID(acct.CellID),
+		Cell:           toCellSummary(acct.Cell, cellCounts[canonicalCellID(acct.CellID)]),
 		Windows:        proj.windows,
 		Stainless:      stainless,
 		Sessions:       sessions,
@@ -198,11 +200,6 @@ func (s *Server) handleUpdateAccountWeight(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleBindAccountCell(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	acct := s.pool.Get(id)
-	if acct == nil {
-		writeAdminError(w, http.StatusNotFound, "not_found", "account not found")
-		return
-	}
 	var req struct {
 		CellID string `json:"cell_id"`
 	}
@@ -211,65 +208,32 @@ func (s *Server) handleBindAccountCell(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.CellID = strings.TrimSpace(req.CellID)
-	if req.CellID != "" {
-		cell := s.pool.GetCell(req.CellID)
-		if cell == nil {
-			writeAdminError(w, http.StatusBadRequest, "invalid_request", "cell not found")
-			return
-		}
-		if req.CellID != acct.CellID {
-			if reason := accountCellBindError(cell, time.Now().UTC()); reason != "" {
-				writeAdminError(w, http.StatusBadRequest, "invalid_request", reason)
-				return
-			}
-			if cell.Proxy == nil || cell.Proxy.Type != "socks5" {
-				if accountOwnsCell(s.pool.List(), acct.ID, req.CellID, acct.Provider) {
-					writeAdminError(w, http.StatusBadRequest, "invalid_request", "cell is already bound to another account of the same provider")
-					return
-				}
-			}
-		}
-	}
-	if err := s.pool.Update(id, func(a *domain.Account) {
-		a.CellID = req.CellID
-	}); err != nil {
-		writeAdminError(w, http.StatusNotFound, "not_found", "account not found")
+	if err := s.pool.BindAccountCell(id, req.CellID, time.Now().UTC()); err != nil {
+		writeAccountCellBindingError(w, err)
 		return
 	}
 	slog.Info("account cell updated", "id", id, "cellId", req.CellID)
 	writeJSON(w, http.StatusOK, map[string]string{"id": id, "cell_id": req.CellID})
 }
 
-func accountCellBindError(cell *domain.EgressCell, now time.Time) string {
-	if cell == nil {
-		return "cell not found"
+func writeAccountCellBindingError(w http.ResponseWriter, err error) {
+	if errors.Is(err, pool.ErrAccountNotFound) {
+		writeAdminError(w, http.StatusNotFound, "not_found", "account not found")
+		return
 	}
-	status := cell.Status
-	if status == "" {
-		status = domain.EgressCellActive
+	if isCellBindingError(err) {
+		writeAdminError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
 	}
-	if status != domain.EgressCellActive {
-		return "cell is not active"
-	}
-	if cell.CooldownUntil != nil && now.Before(*cell.CooldownUntil) {
-		return "cell is cooling down"
-	}
-	if cell.Proxy == nil || strings.TrimSpace(cell.Proxy.Host) == "" || cell.Proxy.Port <= 0 {
-		return "cell has no usable proxy"
-	}
-	return ""
+	writeAdminError(w, http.StatusInternalServerError, "internal_error", "failed to update account cell")
 }
 
-func accountOwnsCell(accounts []*domain.Account, accountID, cellID string, provider domain.Provider) bool {
-	for _, acct := range accounts {
-		if acct == nil || acct.ID == accountID {
-			continue
-		}
-		if acct.CellID == cellID && acct.Provider == provider {
-			return true
-		}
-	}
-	return false
+func isCellBindingError(err error) bool {
+	return errors.Is(err, pool.ErrCellNotFound) ||
+		errors.Is(err, pool.ErrCellInactive) ||
+		errors.Is(err, pool.ErrCellCoolingDown) ||
+		errors.Is(err, pool.ErrCellNoProxy) ||
+		errors.Is(err, pool.ErrCellOccupied)
 }
 
 func (s *Server) handleRefreshAccount(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/admin_cells.go
+++ b/internal/server/admin_cells.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/yansircc/llm-broker/internal/domain"
+	"github.com/yansircc/llm-broker/internal/pool"
 	"golang.org/x/net/proxy"
 )
 
@@ -33,7 +35,7 @@ func (s *Server) handleListEgressCells(w http.ResponseWriter, r *http.Request) {
 			Accounts:      make([]EgressCellAccountRef, 0, counts[cell.ID]),
 		}
 		for _, acct := range accounts {
-			if acct.CellID != cell.ID {
+			if canonicalCellID(acct.CellID) != cell.ID {
 				continue
 			}
 			item.Accounts = append(item.Accounts, EgressCellAccountRef{
@@ -115,6 +117,26 @@ func (s *Server) handleUpsertEgressCell(w http.ResponseWriter, r *http.Request) 
 		UpdatedAt:     saved.UpdatedAt,
 		Accounts:      []EgressCellAccountRef{},
 	})
+}
+
+func (s *Server) handleDeleteEgressCell(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		writeAdminError(w, http.StatusBadRequest, "invalid_request", "cell id is required")
+		return
+	}
+	if err := s.pool.DeleteCell(id); err != nil {
+		switch {
+		case errors.Is(err, pool.ErrCellNotFound):
+			writeAdminError(w, http.StatusNotFound, "not_found", "cell not found")
+		case errors.Is(err, pool.ErrCellInUse):
+			writeAdminError(w, http.StatusConflict, "cell_in_use", "cell has bound accounts")
+		default:
+			writeAdminError(w, http.StatusInternalServerError, "internal_error", "failed to delete cell")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, EgressCellDeleteResponse{ID: id, Deleted: true})
 }
 
 func (s *Server) handleClearEgressCellCooldown(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/admin_dashboard.go
+++ b/internal/server/admin_dashboard.go
@@ -52,7 +52,7 @@ func (s *Server) dashboardAccounts() []DashboardAccount {
 			Weight:          proj.effectiveWeight,
 			CooldownUntil:   acct.CooldownUntil,
 			LastUsedAt:      acct.LastUsedAt,
-			CellID:          acct.CellID,
+			CellID:          canonicalCellID(acct.CellID),
 			AvailableNative: avail.Native,
 			AvailableCompat: avail.Compat,
 			Windows:         proj.windows,

--- a/internal/server/admin_oauth.go
+++ b/internal/server/admin_oauth.go
@@ -126,6 +126,10 @@ func (s *Server) handleExchangeCode(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := s.upsertExchangedAccount(drv, result, req.CellID)
 	if err != nil {
+		if isCellBindingError(err) {
+			writeAdminError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
 		writeAdminError(w, http.StatusInternalServerError, "internal_error", "failed to persist exchanged account")
 		return
 	}

--- a/internal/server/admin_oauth_support.go
+++ b/internal/server/admin_oauth_support.go
@@ -145,20 +145,7 @@ func (s *Server) validateExchangeCellSelection(existing *domain.Account, request
 		currentAccountID = existing.ID
 		currentCellID = existing.CellID
 	}
-	if requestedCellID == currentCellID {
-		return nil
-	}
-
-	cell := s.pool.GetCell(requestedCellID)
-	if reason := accountCellBindError(cell, time.Now().UTC()); reason != "" {
-		return fmt.Errorf("%s", reason)
-	}
-	if cell.Proxy == nil || cell.Proxy.Type != "socks5" {
-		if accountOwnsCell(s.pool.List(), currentAccountID, requestedCellID, provider) {
-			return fmt.Errorf("cell is already bound to another account of the same provider")
-		}
-	}
-	return nil
+	return s.pool.ValidateCellBinding(currentAccountID, provider, currentCellID, requestedCellID, time.Now().UTC())
 }
 
 func (s *Server) oauthClientForRoute(cellID string) (*http.Client, error) {
@@ -173,9 +160,9 @@ func (s *Server) oauthClientForRoute(cellID string) (*http.Client, error) {
 		}), nil
 	}
 
-	cell := s.pool.GetCell(cellID)
-	if reason := accountCellBindError(cell, time.Now().UTC()); reason != "" {
-		return nil, fmt.Errorf("%s", reason)
+	cell, err := s.pool.GetBindableCell(cellID, time.Now().UTC())
+	if err != nil {
+		return nil, err
 	}
 	return s.transportPool.ClientForAccount(&domain.Account{
 		CellID: cellID,
@@ -197,20 +184,25 @@ func (s *Server) updateExchangedAccount(existing *domain.Account, result *driver
 	}
 
 	expiresAt := time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).UnixMilli()
-	if err := s.pool.StoreTokens(existing.ID, encAccess, encRefresh, expiresAt); err != nil {
-		return exchangeAccountResponse{}, err
-	}
-
-	_ = s.pool.Update(existing.ID, func(a *domain.Account) {
+	now := time.Now().UTC()
+	if err := s.pool.Update(existing.ID, func(a *domain.Account) {
 		a.Email = result.Email
 		a.Status = domain.StatusActive
+		a.ErrorMessage = ""
+		a.RefreshTokenEnc = encRefresh
+		a.AccessTokenEnc = encAccess
+		a.ExpiresAt = expiresAt
+		a.CooldownUntil = nil
+		a.LastRefreshAt = &now
 		a.Identity = result.Identity
 		a.Subject = result.Subject
 		a.CellID = cellID
 		if len(result.ProviderState) > 0 {
 			a.ProviderStateJSON = string(result.ProviderState)
 		}
-	})
+	}); err != nil {
+		return exchangeAccountResponse{}, err
+	}
 
 	return exchangeAccountResponse{
 		ID:     existing.ID,

--- a/internal/server/admin_oauth_test.go
+++ b/internal/server/admin_oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -320,6 +321,58 @@ func TestHandleExchangeCodeCreatesAccountBoundToCell(t *testing.T) {
 	}
 }
 
+func TestCreateExchangedAccountRejectsDeletedCellAfterPreflight(t *testing.T) {
+	ms := store.NewMockStore()
+	bus := events.NewBus(100)
+	p, err := pool.New(ms, bus)
+	if err != nil {
+		t.Fatalf("pool.New() error = %v", err)
+	}
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11083},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell() error = %v", err)
+	}
+
+	c := crypto.New("test-encryption-key")
+	tm := tokens.NewManager(p, c, nil, time.Minute, 0, nil)
+	stub := &exchangeStubDriver{provider: domain.ProviderClaude}
+	srv := &Server{
+		cfg:    &config.Config{},
+		store:  ms,
+		pool:   p,
+		tokens: tm,
+		bus:    bus,
+	}
+	result := &driver.ExchangeResult{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresIn:    3600,
+		Subject:      "sub-race",
+		Email:        "race@example.com",
+	}
+
+	if err := srv.validateExchangeCellSelection(nil, "cell-race", domain.ProviderClaude); err != nil {
+		t.Fatalf("validateExchangeCellSelection(): %v", err)
+	}
+	if err := p.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	_, err = srv.createExchangedAccount(stub, result, "cell-race")
+	if !errors.Is(err, pool.ErrCellNotFound) {
+		t.Fatalf("createExchangedAccount() = %v, want %v", err, pool.ErrCellNotFound)
+	}
+	if accounts := p.List(); len(accounts) != 0 {
+		t.Fatalf("len(accounts) = %d, want 0", len(accounts))
+	}
+}
+
 func TestHandleExchangeCodeAllowsLegacyDirectForNewAccount(t *testing.T) {
 	ms := store.NewMockStore()
 	bus := events.NewBus(100)
@@ -482,5 +535,87 @@ func TestHandleExchangeCodePreservesExistingRefreshTokenOnRebind(t *testing.T) {
 	}
 	if refreshToken != "old-refresh" {
 		t.Fatalf("refresh token = %q, want old-refresh", refreshToken)
+	}
+}
+
+func TestUpdateExchangedAccountRejectsDeletedCellAfterPreflight(t *testing.T) {
+	ms := store.NewMockStore()
+	bus := events.NewBus(100)
+	p, err := pool.New(ms, bus)
+	if err != nil {
+		t.Fatalf("pool.New() error = %v", err)
+	}
+
+	c := crypto.New("test-encryption-key")
+	tm := tokens.NewManager(p, c, nil, time.Minute, 0, nil)
+	oldRefreshEnc, err := tm.EncryptToken("old-refresh")
+	if err != nil {
+		t.Fatalf("EncryptToken(old refresh) error = %v", err)
+	}
+	oldAccessEnc, err := tm.EncryptToken("old-access")
+	if err != nil {
+		t.Fatalf("EncryptToken(old access) error = %v", err)
+	}
+	existing := &domain.Account{
+		ID:              "acct-race",
+		Email:           "old@example.com",
+		Provider:        domain.ProviderClaude,
+		Subject:         "sub-race",
+		Status:          domain.StatusActive,
+		Priority:        50,
+		PriorityMode:    "auto",
+		RefreshTokenEnc: oldRefreshEnc,
+		AccessTokenEnc:  oldAccessEnc,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := p.Add(existing); err != nil {
+		t.Fatalf("pool.Add() error = %v", err)
+	}
+	if err := p.SaveCell(&domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11083},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveCell() error = %v", err)
+	}
+
+	srv := &Server{
+		cfg:    &config.Config{},
+		store:  ms,
+		pool:   p,
+		tokens: tm,
+		bus:    bus,
+	}
+	result := &driver.ExchangeResult{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresIn:    3600,
+		Subject:      "sub-race",
+		Email:        "new@example.com",
+	}
+
+	if err := srv.validateExchangeCellSelection(existing, "cell-race", domain.ProviderClaude); err != nil {
+		t.Fatalf("validateExchangeCellSelection(): %v", err)
+	}
+	if err := p.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	_, err = srv.updateExchangedAccount(existing, result, "cell-race")
+	if !errors.Is(err, pool.ErrCellNotFound) {
+		t.Fatalf("updateExchangedAccount() = %v, want %v", err, pool.ErrCellNotFound)
+	}
+	acct := p.Get(existing.ID)
+	if acct == nil {
+		t.Fatal("account not found after failed update")
+	}
+	if acct.CellID != "" {
+		t.Fatalf("CellID = %q, want empty", acct.CellID)
+	}
+	if acct.Email != "old@example.com" {
+		t.Fatalf("Email = %q, want old@example.com", acct.Email)
 	}
 }

--- a/internal/server/cell_view.go
+++ b/internal/server/cell_view.go
@@ -1,6 +1,14 @@
 package server
 
-import "github.com/yansircc/llm-broker/internal/domain"
+import (
+	"strings"
+
+	"github.com/yansircc/llm-broker/internal/domain"
+)
+
+func canonicalCellID(cellID string) string {
+	return strings.TrimSpace(cellID)
+}
 
 func toCellSummary(cell *domain.EgressCell, accountCount int) *EgressCellSummaryResponse {
 	if cell == nil {
@@ -23,8 +31,9 @@ func toCellSummary(cell *domain.EgressCell, accountCount int) *EgressCellSummary
 func accountCountsByCell(accounts []*domain.Account) map[string]int {
 	counts := make(map[string]int)
 	for _, acct := range accounts {
-		if acct.CellID != "" {
-			counts[acct.CellID]++
+		cellID := canonicalCellID(acct.CellID)
+		if cellID != "" {
+			counts[cellID]++
 		}
 	}
 	return counts

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -557,6 +558,147 @@ func TestListEgressCells_EmptyAccountsArray(t *testing.T) {
 	}
 }
 
+func TestListEgressCells_CanonicalizesLegacyAccountCellID(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-dirty",
+		Email:    "dirty@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+		CellID:   " cell-dirty ",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-dirty",
+		Name:      "dirty cell",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+
+	w := httptest.NewRecorder()
+	srv.handleListEgressCells(w, adminRequest("GET", "/admin/egress/cells"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	accounts, ok := result[0]["accounts"].([]any)
+	if !ok {
+		t.Fatalf("accounts is %T, want []", result[0]["accounts"])
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("len(accounts) = %d, want 1", len(accounts))
+	}
+	if err := srv.pool.DeleteCell("cell-dirty"); !errors.Is(err, pool.ErrCellInUse) {
+		t.Fatalf("DeleteCell(cell-dirty) = %v, want %v", err, pool.ErrCellInUse)
+	}
+}
+
+func TestDeleteEgressCell_RemovesUnboundCell(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-unused",
+		Name:      "unused",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+
+	w := httptest.NewRecorder()
+	r := adminRequest(http.MethodDelete, "/admin/egress/cells/cell-unused")
+	r.SetPathValue("id", "cell-unused")
+	srv.handleDeleteEgressCell(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := jsonPath(t, w.Body.Bytes(), "deleted"); got != true {
+		t.Fatalf("deleted = %#v, want true", got)
+	}
+	cell, err := srv.store.GetEgressCell(context.Background(), "cell-unused")
+	if err != nil {
+		t.Fatalf("GetEgressCell(): %v", err)
+	}
+	if cell != nil {
+		t.Fatalf("GetEgressCell() = %#v, want nil", cell)
+	}
+}
+
+func TestDeleteEgressCell_RejectsBoundCell(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-bound",
+		Email:    "bound@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+		CellID:   "cell-bound",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-bound",
+		Name:      "bound",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 11080},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+
+	w := httptest.NewRecorder()
+	r := adminRequest(http.MethodDelete, "/admin/egress/cells/cell-bound")
+	r.SetPathValue("id", "cell-bound")
+	srv.handleDeleteEgressCell(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status %d, want %d, body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cell_in_use") {
+		t.Fatalf("body %q does not mention cell_in_use", w.Body.String())
+	}
+	if cell := srv.pool.GetCell("cell-bound"); cell == nil {
+		t.Fatal("bound cell should remain")
+	}
+	if acct := srv.pool.Get("acct-bound"); acct == nil || acct.CellID != "cell-bound" {
+		t.Fatalf("account cell_id = %#v, want cell-bound", acct)
+	}
+}
+
+func TestDeleteEgressCell_NotFound(t *testing.T) {
+	srv := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	r := adminRequest(http.MethodDelete, "/admin/egress/cells/missing")
+	r.SetPathValue("id", "missing")
+	srv.handleDeleteEgressCell(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want %d, body: %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
 func TestBindAccountCell_RejectsCoolingCell(t *testing.T) {
 	srv := newTestServer(t)
 
@@ -632,6 +774,53 @@ func TestBindAccountCell_AllowsActiveCell(t *testing.T) {
 	saved := srv.pool.Get("acct-2")
 	if saved == nil || saved.CellID != "cell-fr-linode-02" {
 		t.Fatalf("account cell_id = %q, want cell-fr-linode-02", saved.CellID)
+	}
+}
+
+func TestBindAccountCell_RejectsDeletedCellAfterPreflight(t *testing.T) {
+	srv := newTestServer(t)
+
+	if err := srv.store.SaveAccount(context.Background(), &domain.Account{
+		ID:       "acct-race",
+		Email:    "race@example.com",
+		Provider: domain.ProviderClaude,
+		Status:   domain.StatusActive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.SaveEgressCell(context.Background(), &domain.EgressCell{
+		ID:        "cell-race",
+		Name:      "cell race",
+		Status:    domain.EgressCellActive,
+		Proxy:     &domain.ProxyConfig{Type: "socks5", Host: "127.0.0.1", Port: 1083},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.pool, _ = pool.New(srv.store, srv.bus)
+
+	if cell := srv.pool.GetCell("cell-race"); cell == nil {
+		t.Fatal("preflight expected cell-race to exist")
+	}
+	if err := srv.pool.DeleteCell("cell-race"); err != nil {
+		t.Fatalf("DeleteCell(cell-race): %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/admin/accounts/acct-race/cell", strings.NewReader(`{"cell_id":"cell-race"}`))
+	r = r.WithContext(adminRequest(http.MethodPost, "/admin/accounts/acct-race/cell").Context())
+	r.SetPathValue("id", "acct-race")
+	srv.handleBindAccountCell(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want %d, body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cell not found") {
+		t.Fatalf("body %q does not mention missing cell", w.Body.String())
+	}
+	if saved := srv.pool.Get("acct-race"); saved == nil || saved.CellID != "" {
+		t.Fatalf("account cell_id = %#v, want empty", saved)
 	}
 }
 

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -211,6 +211,11 @@ type EgressCellAccountRef struct {
 	Status   string `json:"status"`
 }
 
+type EgressCellDeleteResponse struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
 // ---------------------------------------------------------------------------
 // Account Test Result
 // ---------------------------------------------------------------------------

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -58,6 +58,7 @@ func (s *Server) registerAdminRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /admin/egress/cells", admin(s.handleListEgressCells))
 	mux.Handle("POST /admin/egress/cells", admin(s.handleUpsertEgressCell))
 	mux.Handle("POST /admin/egress/cells/test-proxy", admin(s.handleTestProxy))
+	mux.Handle("DELETE /admin/egress/cells/{id}", admin(s.handleDeleteEgressCell))
 	mux.Handle("POST /admin/egress/cells/{id}/clear-cooldown", admin(s.handleClearEgressCellCooldown))
 	mux.Handle("POST /admin/egress/cells/{id}/test", admin(s.handleTestEgressCell))
 

--- a/web/src/routes/cells/[id]/+page.svelte
+++ b/web/src/routes/cells/[id]/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
 	import { api } from '$lib/api';
 	import type { EgressCellView } from '$lib/admin-types';
 	import { fmtDate, dotClass } from '$lib/format';
+	import ConfirmAction from '$lib/components/ConfirmAction.svelte';
 
 	let cell = $state<EgressCellView | null>(null);
 	let error = $state('');
@@ -11,6 +13,7 @@
 	let actionError = $state('');
 	let clearing = $state(false);
 	let testing = $state(false);
+	let deleting = $state(false);
 	let testResult = $state<{ ok: boolean; latency_ms?: number; error?: string } | null>(null);
 
 	$effect(() => {
@@ -52,6 +55,20 @@
 
 	function cellAccounts(item: EgressCellView): NonNullable<EgressCellView['accounts']> {
 		return item.accounts ?? [];
+	}
+
+	async function deleteCell() {
+		if (!cell || deleting || cellAccounts(cell).length > 0) return;
+		deleting = true;
+		actionError = '';
+		try {
+			await api(`/egress/cells/${cell.id}`, { method: 'DELETE' });
+			goto(`${base}/dashboard`);
+		} catch (e: any) {
+			actionError = e.message;
+		} finally {
+			deleting = false;
+		}
 	}
 
 	async function clearCooldown() {
@@ -96,6 +113,9 @@
 		<button class="link" onclick={testCell} disabled={testing}>{testing ? '[testing...]' : '[test proxy]'}</button>
 		{#if cooldownActive(cell)}
 			<button class="link o" onclick={clearCooldown} disabled={clearing}>{clearing ? '[clearing...]' : '[clear cooldown]'}</button>
+		{/if}
+		{#if cellAccounts(cell).length === 0}
+			<ConfirmAction label={deleting ? '[deleting...]' : '[delete]'} cls="r" onclick={deleteCell} />
 		{/if}
 		{#if testResult}
 			{#if testResult.ok}


### PR DESCRIPTION
## Invariant

`accounts.cell_id` is the single account-to-egress-cell binding. A cell can be deleted only when no account is bound to its canonical cell ID; whitespace variants such as `" cell-http "` still refer to `cell-http`.

## Failure

Cell deletion and account/cell projections did not consistently canonicalize `cell_id`, so legacy dirty bindings could be missed by delete protection or egress cell list projection. The UI also had no delete action for cells that were already unbound.

## Minimal fix

- Add pool-level canonical `cell_id` handling for account add/update/bind, delete protection, and projected account views.
- Move binding validation into the pool so admin account binding and OAuth exchange use the same invariant.
- Add `DELETE /admin/egress/cells/{id}` with `404` for missing cells and `409` for bound cells.
- Show a confirmed delete action on the cell detail page only when the projected bound account list is empty.
- Document egress cell delete/unbind flow in `docs/egress-cell-operations.md` and list the admin cell APIs in `README.md`.

## Verification

- `cd web && npm run build`
- `git diff --check HEAD^..HEAD`

Local Go verification was not rerun during PR preparation because this machine shell has no `go` binary on PATH (`go version` returns `command not found`). The repository CI installs Go 1.24 and runs `go build ./...` plus `go test ./...` on the PR.
